### PR TITLE
refactor: remove unnecessary_literal_bound directives

### DIFF
--- a/ferrotunnel-plugin/src/builtin/auth.rs
+++ b/ferrotunnel-plugin/src/builtin/auth.rs
@@ -25,7 +25,6 @@ impl TokenAuthPlugin {
 
 #[async_trait]
 impl Plugin for TokenAuthPlugin {
-    #[allow(clippy::unnecessary_literal_bound)]
     fn name(&self) -> &str {
         "token-auth"
     }

--- a/ferrotunnel-plugin/src/builtin/circuit_breaker.rs
+++ b/ferrotunnel-plugin/src/builtin/circuit_breaker.rs
@@ -173,12 +173,10 @@ impl std::fmt::Debug for CircuitBreakerPlugin {
 
 #[async_trait]
 impl Plugin for CircuitBreakerPlugin {
-    #[allow(clippy::unnecessary_literal_bound)]
     fn name(&self) -> &str {
         "circuit-breaker"
     }
 
-    #[allow(clippy::unnecessary_literal_bound)]
     fn version(&self) -> &str {
         "1.0.0"
     }

--- a/ferrotunnel-plugin/src/builtin/logger.rs
+++ b/ferrotunnel-plugin/src/builtin/logger.rs
@@ -27,7 +27,6 @@ impl Default for LoggerPlugin {
 
 #[async_trait]
 impl Plugin for LoggerPlugin {
-    #[allow(clippy::unnecessary_literal_bound)]
     fn name(&self) -> &str {
         "logger"
     }

--- a/ferrotunnel-plugin/src/builtin/rate_limit.rs
+++ b/ferrotunnel-plugin/src/builtin/rate_limit.rs
@@ -38,7 +38,6 @@ impl RateLimitPlugin {
 
 #[async_trait]
 impl Plugin for RateLimitPlugin {
-    #[allow(clippy::unnecessary_literal_bound)]
     fn name(&self) -> &str {
         "rate-limit"
     }


### PR DESCRIPTION
Hello!
This PR closes #77.

### Changes
Remove `#[allow(clippy::unnecessary_literal_bound)]` from:

- ferrotunnel-plugin/src/builtin/auth.rs:28
- ferrotunnel-plugin/src/builtin/rate_limit.rs:41
- ferrotunnel-plugin/src/builtin/logger.rs:30
- ferrotunnel-plugin/src/builtin/circuit_breaker.rs:176
- ferrotunnel-plugin/src/builtin/circuit_breaker.rs:181

### Testing
I run `cargo clippy` for each removed directive to check if there are any warnings, and there were't any.