### PR TITLE
refactor: reduce boolean fields

### DIFF
--- a/ferrotunnel-cli/README.md
+++ b/ferrotunnel-cli/README.md
@@ -36,7 +36,8 @@ ferrotunnel server --token my-secret-token
 | `--token` | `FERROTUNNEL_TOKEN` | (required) | Authentication token |
 | `--log-level` | `RUST_LOG` | `info` | Log level |
 | `--metrics-bind` | `FERROTUNNEL_METRICS_BIND` | `0.0.0.0:9090` | Prometheus metrics address |
-| `--observability` | `FERROTUNNEL_OBSERVABILITY` | `false` | Enable metrics and tracing |
+| `--observability` | `FERROTUNNEL_OBSERVABILITY` | `false` | Enable tracing |
+| `--metrics` | `FERROTUNNEL_METRICS` | `false` | Enable Prometheus metrics endpoint |
 | `--tls-cert` | `FERROTUNNEL_TLS_CERT` | - | TLS certificate file path |
 | `--tls-key` | `FERROTUNNEL_TLS_KEY` | - | TLS private key file path |
 | `--tls-ca` | `FERROTUNNEL_TLS_CA` | - | CA certificate for client auth |
@@ -70,7 +71,8 @@ ferrotunnel client --server tunnel.example.com:7835
 | `--dashboard-port` | `FERROTUNNEL_DASHBOARD_PORT` | `4040` | Dashboard port |
 | `--no-dashboard` | - | `false` | Disable dashboard |
 | `--log-level` | `RUST_LOG` | `info` | Log level |
-| `--observability` | `FERROTUNNEL_OBSERVABILITY` | `false` | Enable metrics and tracing |
+| `--observability` | `FERROTUNNEL_OBSERVABILITY` | `false` | Enable tracing |
+| `--metrics` | `FERROTUNNEL_METRICS` | `false` | Enable metrics collection |
 | `--tls` | `FERROTUNNEL_TLS` | `false` | Enable TLS |
 | `--tls-skip-verify` | `FERROTUNNEL_TLS_SKIP_VERIFY` | `false` | Skip certificate verification |
 | `--tls-ca` | `FERROTUNNEL_TLS_CA` | - | CA certificate path |

--- a/ferrotunnel-cli/src/commands/client.rs
+++ b/ferrotunnel-cli/src/commands/client.rs
@@ -40,7 +40,7 @@ where
     }
 }
 
-/// TLS and connection feature flags (flattened into ClientArgs)
+/// Client feature configuration (dashboard, TLS, telemetry; flattened into ClientArgs)
 #[derive(Args, Debug)]
 pub struct ClientFeatureArgs {
     /// Dashboard config struct
@@ -56,7 +56,7 @@ pub struct ClientFeatureArgs {
     pub telemetry: TelemetryConfig,
 }
 
-/// Dashboard config (flattened into ClientFeatureArgs)
+/// Dashboard configuration for tunnel inspection (flattened into ClientFeatureArgs)
 #[derive(Args, Debug)]
 pub struct DashboardConfig {
     /// Dashboard port
@@ -72,7 +72,7 @@ pub struct DashboardConfig {
     pub disabled: bool,
 }
 
-/// TLS config (flattened into ClientFeatureArgs)
+/// TLS configuration for secure server connections (flattened into ClientFeatureArgs)
 #[derive(Args, Debug)]
 pub struct TlsConfig {
     /// Enable TLS for server connection
@@ -84,7 +84,7 @@ pub struct TlsConfig {
     pub skip_verify: bool,
 }
 
-/// Telemetry config (flattened into ClientFeatureArgs)
+/// Telemetry and observability configuration (flattened into ClientFeatureArgs)
 #[derive(Args, Debug)]
 pub struct TelemetryConfig {
     /// Enable tracing (metrics is separate via --metrics)


### PR DESCRIPTION
Hello!
This PR closes #76 
I think the proposed option B is a little bit more readable and accessable.

### Changes

#### ferrotunnel-cli/src/commands/client.rs

---

##### Refactor `ClientFeatureArgs` and split it into 3 structs:
`DashboardConfig` - Contains `port` and `disabled` field now

`TlsConfig` - Contains `enabled` and `skip_verify` field now

`TelemetryConfig` - Contains `observability` and `metrics` field now

---

I also changed up the variables used in `client.rs` to match the new fields.

Also removal of `#[allow(clippy::struct_excessive_bools)]`

---

### Testing
`make check` - no issues
`cargo test` - no issues

---

Please review, and have a nice day :heart: 