### PR TITLE
fix: wire frame limits into tunnel codec

### DIFF
--- a/ferrotunnel-core/src/tunnel/client.rs
+++ b/ferrotunnel-core/src/tunnel/client.rs
@@ -3,7 +3,7 @@ use crate::stream::{Multiplexer, PrioritizedFrame, VirtualStream};
 use crate::transport::batched_sender::run_batched_sender;
 use crate::transport::{self, TransportConfig};
 use crate::tunnel::common::clamp_u128_to_u64;
-use ferrotunnel_common::{Result, TunnelError};
+use ferrotunnel_common::{LimitsConfig, Result, TunnelError};
 use ferrotunnel_protocol::codec::TunnelCodec;
 use ferrotunnel_protocol::constants::{MAX_PROTOCOL_VERSION, MIN_PROTOCOL_VERSION};
 use ferrotunnel_protocol::frame::{Frame, HandshakeFrame, HandshakeStatus};
@@ -27,6 +27,7 @@ pub struct TunnelClient {
     session_id: Option<Uuid>,
     tunnel_id: Option<String>,
     transport_config: TransportConfig,
+    limits_config: LimitsConfig,
 }
 
 impl TunnelClient {
@@ -37,12 +38,19 @@ impl TunnelClient {
             session_id: None,
             tunnel_id: None,
             transport_config: TransportConfig::default(),
+            limits_config: LimitsConfig::default(),
         }
     }
 
     #[must_use]
     pub fn with_transport(mut self, config: TransportConfig) -> Self {
         self.transport_config = config;
+        self
+    }
+
+    #[must_use]
+    pub fn with_limits(mut self, limits: LimitsConfig) -> Self {
+        self.limits_config = limits;
         self
     }
 
@@ -150,7 +158,7 @@ impl TunnelClient {
         let stream = transport::connect(&self.transport_config, &self.server_addr).await?;
         info!("Connected to {}", self.server_addr);
 
-        let mut framed = Framed::new(stream, TunnelCodec::new());
+        let mut framed = Framed::new(stream, TunnelCodec::from_limits(&self.limits_config));
         let session_id = Self::handshake(&mut framed, self, on_connected).await?;
         self.session_id = Some(session_id);
 
@@ -206,10 +214,14 @@ impl TunnelClient {
             .await
             .map_err(|e| TunnelError::Connection(format!("QUIC open control stream: {e}")))?;
 
-        let mut ctrl_framed_send =
-            tokio_util::codec::FramedWrite::new(ctrl_send, TunnelCodec::new());
-        let mut ctrl_framed_recv =
-            tokio_util::codec::FramedRead::new(ctrl_recv, TunnelCodec::new());
+        let mut ctrl_framed_send = tokio_util::codec::FramedWrite::new(
+            ctrl_send,
+            TunnelCodec::from_limits(&self.limits_config),
+        );
+        let mut ctrl_framed_recv = tokio_util::codec::FramedRead::new(
+            ctrl_recv,
+            TunnelCodec::from_limits(&self.limits_config),
+        );
 
         // Handshake
         ctrl_framed_send

--- a/ferrotunnel-core/src/tunnel/server.rs
+++ b/ferrotunnel-core/src/tunnel/server.rs
@@ -5,7 +5,7 @@ use crate::transport::batched_sender::run_batched_sender;
 use crate::transport::{self, BoxedStream, TransportConfig};
 use crate::tunnel::common::clamp_u128_to_u64;
 use crate::tunnel::session::{Session, SessionStoreBackend, ShardedSessionStore};
-use ferrotunnel_common::{Result, TunnelError};
+use ferrotunnel_common::{LimitsConfig, Result, TunnelError};
 use ferrotunnel_protocol::codec::TunnelCodec;
 use ferrotunnel_protocol::constants::{MAX_PROTOCOL_VERSION, MIN_PROTOCOL_VERSION};
 use ferrotunnel_protocol::frame::{Frame, HandshakeFrame, HandshakeStatus};
@@ -30,6 +30,7 @@ pub struct TunnelServer {
     session_timeout: Duration,
     resource_limits: ServerResourceLimits,
     transport_config: TransportConfig,
+    limits_config: LimitsConfig,
 }
 
 impl TunnelServer {
@@ -41,6 +42,7 @@ impl TunnelServer {
             session_timeout: Duration::from_secs(90),
             resource_limits: ServerResourceLimits::default(),
             transport_config: TransportConfig::default(),
+            limits_config: LimitsConfig::default(),
         }
     }
 
@@ -54,6 +56,12 @@ impl TunnelServer {
     #[must_use]
     pub fn with_resource_limits(mut self, limits: ServerResourceLimits) -> Self {
         self.resource_limits = limits;
+        self
+    }
+
+    #[must_use]
+    pub fn with_limits(mut self, limits: LimitsConfig) -> Self {
+        self.limits_config = limits;
         self
     }
 
@@ -149,11 +157,18 @@ impl TunnelServer {
 
                     let sessions = sessions.clone();
                     let token = self.auth_token.clone();
+                    let limits = self.limits_config.clone();
 
                     tokio::spawn(async move {
-                        if let Err(e) =
-                            Self::handle_connection(stream, addr, sessions, token, session_permit)
-                                .await
+                        if let Err(e) = Self::handle_connection(
+                            stream,
+                            addr,
+                            sessions,
+                            token,
+                            session_permit,
+                            limits,
+                        )
+                        .await
                         {
                             warn!("Connection error for {}: {}", addr, e);
                         }
@@ -173,8 +188,9 @@ impl TunnelServer {
         sessions: SessionStoreBackend,
         expected_token: String,
         _session_permit: SessionPermit,
+        limits_config: LimitsConfig,
     ) -> Result<()> {
-        let mut framed = Framed::new(stream, TunnelCodec::new());
+        let mut framed = Framed::new(stream, TunnelCodec::from_limits(&limits_config));
 
         // 1. Handshake
         if let Some(result) = framed.next().await {
@@ -380,6 +396,7 @@ impl TunnelServer {
 
                     let sessions = sessions.clone();
                     let token = self.auth_token.clone();
+                    let limits = self.limits_config.clone();
 
                     tokio::spawn(async move {
                         if let Err(e) = Self::handle_quic_connection(
@@ -388,6 +405,7 @@ impl TunnelServer {
                             sessions,
                             token,
                             session_permit,
+                            limits,
                         )
                         .await
                         {
@@ -413,6 +431,7 @@ impl TunnelServer {
         sessions: SessionStoreBackend,
         expected_token: String,
         _session_permit: SessionPermit,
+        limits_config: LimitsConfig,
     ) -> Result<()> {
         // Accept the control stream (first bidi stream opened by client)
         let (ctrl_send, ctrl_recv) = connection
@@ -421,9 +440,11 @@ impl TunnelServer {
             .map_err(|e| TunnelError::Connection(format!("QUIC control stream accept: {e}")))?;
 
         let mut ctrl_framed_recv =
-            tokio_util::codec::FramedRead::new(ctrl_recv, TunnelCodec::new());
-        let mut ctrl_framed_send =
-            tokio_util::codec::FramedWrite::new(ctrl_send, TunnelCodec::new());
+            tokio_util::codec::FramedRead::new(ctrl_recv, TunnelCodec::from_limits(&limits_config));
+        let mut ctrl_framed_send = tokio_util::codec::FramedWrite::new(
+            ctrl_send,
+            TunnelCodec::from_limits(&limits_config),
+        );
 
         // 1. Handshake on control stream
         let frame = ctrl_framed_recv

--- a/ferrotunnel-protocol/Cargo.toml
+++ b/ferrotunnel-protocol/Cargo.toml
@@ -10,6 +10,7 @@ description = "Wire protocol for FerroTunnel reverse tunnel"
 keywords = ["protocol", "tunnel", "networking"]
 
 [dependencies]
+ferrotunnel-common = { version = "1.0.8", path = "../ferrotunnel-common" }
 serde = { workspace = true }
 bincode-next = { workspace = true }
 bytes = { workspace = true }

--- a/ferrotunnel-protocol/src/codec.rs
+++ b/ferrotunnel-protocol/src/codec.rs
@@ -10,11 +10,13 @@
 use crate::constants::MAX_FRAME_SIZE;
 use crate::frame::{Frame, ZeroCopyFrame};
 use bytes::{Buf, BufMut, BytesMut};
+use ferrotunnel_common::LimitsConfig;
 use std::io;
 use tokio_util::codec::{Decoder, Encoder};
 
 /// Frame header size: 4 bytes length + 1 byte type
 const HEADER_SIZE: usize = 5;
+const MIN_MAX_FRAME_SIZE: usize = 1;
 
 const FRAME_TYPE_CONTROL: u8 = 0x00;
 const FRAME_TYPE_DATA: u8 = 0x01;
@@ -42,9 +44,7 @@ pub struct TunnelCodec {
 
 impl Default for TunnelCodec {
     fn default() -> Self {
-        Self {
-            max_frame_size: MAX_FRAME_SIZE as usize,
-        }
+        Self::with_max_frame_size(MAX_FRAME_SIZE as usize)
     }
 }
 
@@ -58,7 +58,25 @@ impl TunnelCodec {
     /// Create a new codec instance with a custom max frame size
     #[inline]
     pub fn with_max_frame_size(max_frame_size: usize) -> Self {
+        assert!(
+            max_frame_size >= MIN_MAX_FRAME_SIZE,
+            "max frame size must be greater than zero"
+        );
+        assert!(
+            u32::try_from(max_frame_size).is_ok(),
+            "max frame size must fit in the wire length prefix"
+        );
         Self { max_frame_size }
+    }
+
+    /// Create a new codec instance from configured resource limits.
+    #[inline]
+    pub fn from_limits(limits: &LimitsConfig) -> Self {
+        let max_frame_size = match usize::try_from(limits.max_frame_bytes) {
+            Ok(max_frame_size) => max_frame_size,
+            Err(error) => panic!("max frame size must fit in usize: {error}"),
+        };
+        Self::with_max_frame_size(max_frame_size)
     }
 
     /// Get the configured max frame size
@@ -453,6 +471,32 @@ mod tests {
 
         // Should fail validation before trying to read more
         let result = codec.decode(&mut buf);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    #[should_panic(expected = "max frame size must be greater than zero")]
+    fn test_zero_max_frame_size_rejected() {
+        let _codec = TunnelCodec::with_max_frame_size(0);
+    }
+
+    #[test]
+    fn test_from_limits_enforces_configured_frame_size() {
+        let limits = LimitsConfig {
+            max_frame_bytes: 8,
+            ..Default::default()
+        };
+        let mut codec = TunnelCodec::from_limits(&limits);
+        assert_eq!(codec.max_frame_size(), 8);
+        let mut buf = BytesMut::new();
+
+        let frame = Frame::Data {
+            stream_id: 1,
+            data: Bytes::from_static(b"abc"),
+            end_of_stream: false,
+        };
+
+        let result = codec.encode(frame, &mut buf);
         assert!(result.is_err());
     }
 

--- a/ferrotunnel-protocol/src/validation.rs
+++ b/ferrotunnel-protocol/src/validation.rs
@@ -1,6 +1,7 @@
 //! Frame validation for security hardening
 
 use crate::frame::Frame;
+use ferrotunnel_common::LimitsConfig;
 
 /// Validation errors
 #[derive(Debug, thiserror::Error)]
@@ -33,12 +34,18 @@ pub struct ValidationLimits {
 
 impl Default for ValidationLimits {
     fn default() -> Self {
+        Self::from(&LimitsConfig::default())
+    }
+}
+
+impl From<&LimitsConfig> for ValidationLimits {
+    fn from(limits: &LimitsConfig) -> Self {
         Self {
-            max_frame_bytes: 16 * 1024 * 1024,
-            max_token_len: 256,
-            max_capabilities: 32,
-            max_capability_len: 64,
-            max_payload_bytes: 16 * 1024 * 1024,
+            max_frame_bytes: limits.max_frame_bytes,
+            max_token_len: limits.max_token_len,
+            max_capabilities: limits.max_capabilities,
+            max_capability_len: limits.max_capability_len,
+            max_payload_bytes: usize::try_from(limits.max_frame_bytes).unwrap_or(usize::MAX),
         }
     }
 }
@@ -96,4 +103,27 @@ pub fn validate_frame(frame: &Frame, limits: &ValidationLimits) -> Result<(), Va
         _ => {}
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_validation_limits_from_limits_config() {
+        let limits = LimitsConfig {
+            max_frame_bytes: 4096,
+            max_token_len: 32,
+            max_capabilities: 4,
+            max_capability_len: 16,
+            ..Default::default()
+        };
+        let validation = ValidationLimits::from(&limits);
+
+        assert_eq!(validation.max_frame_bytes, 4096);
+        assert_eq!(validation.max_payload_bytes, 4096);
+        assert_eq!(validation.max_token_len, 32);
+        assert_eq!(validation.max_capabilities, 4);
+        assert_eq!(validation.max_capability_len, 16);
+    }
 }

--- a/ferrotunnel/src/client.rs
+++ b/ferrotunnel/src/client.rs
@@ -19,7 +19,7 @@
 //! ```
 
 use crate::config::{ClientConfig, TunnelInfo};
-use ferrotunnel_common::config::TlsConfig;
+use ferrotunnel_common::config::{LimitsConfig, TlsConfig};
 use ferrotunnel_common::{Result, TunnelError};
 use ferrotunnel_core::transport::{tls::TlsTransportConfig, TransportConfig};
 use ferrotunnel_core::TunnelClient;
@@ -99,6 +99,7 @@ impl Client {
         let tunnel_id = config.tunnel_id.clone();
         let auto_reconnect = config.auto_reconnect;
         let reconnect_delay = config.reconnect_delay;
+        let limits = config.limits.clone();
         let transport_config = self.transport_config.clone();
 
         let info_tx = Arc::new(Mutex::new(Some(info_tx)));
@@ -116,7 +117,8 @@ impl Client {
 
             loop {
                 let mut client = TunnelClient::new(server_addr.clone(), token.clone())
-                    .with_transport(transport_config.clone());
+                    .with_transport(transport_config.clone())
+                    .with_limits(limits.clone());
                 if let Some(ref id) = tunnel_id {
                     client = client.with_tunnel_id(id.clone());
                 }
@@ -325,6 +327,13 @@ impl ClientBuilder {
         self
     }
 
+    /// Configure resource limits.
+    #[must_use]
+    pub fn limits(mut self, limits: &LimitsConfig) -> Self {
+        self.config.limits = limits.clone();
+        self
+    }
+
     /// Configure TLS for the connection.
     ///
     /// When enabled, the client will use TLS to connect to the server.
@@ -392,6 +401,10 @@ mod tests {
             .local_addr("127.0.0.1:3000")
             .auto_reconnect(false)
             .reconnect_delay(Duration::from_secs(10))
+            .limits(&LimitsConfig {
+                max_frame_bytes: 4096,
+                ..Default::default()
+            })
             .build()
             .expect("should build successfully");
 
@@ -400,6 +413,7 @@ mod tests {
         assert_eq!(client.config().local_addr, "127.0.0.1:3000");
         assert!(!client.config().auto_reconnect);
         assert_eq!(client.config().reconnect_delay, Duration::from_secs(10));
+        assert_eq!(client.config().limits.max_frame_bytes, 4096);
     }
 
     #[test]

--- a/ferrotunnel/src/config.rs
+++ b/ferrotunnel/src/config.rs
@@ -4,7 +4,7 @@
 //! in your applications.
 
 use ferrotunnel_common::{
-    Result, TunnelError, DEFAULT_HTTP_PORT, DEFAULT_LOCAL_ADDR, DEFAULT_TUNNEL_PORT,
+    LimitsConfig, Result, TunnelError, DEFAULT_HTTP_PORT, DEFAULT_LOCAL_ADDR, DEFAULT_TUNNEL_PORT,
 };
 use std::net::SocketAddr;
 #[cfg(feature = "http3")]
@@ -33,6 +33,9 @@ pub struct ClientConfig {
 
     /// Delay between reconnection attempts
     pub reconnect_delay: Duration,
+
+    /// Resource limits for protocol framing and connection handling.
+    pub limits: LimitsConfig,
 }
 
 impl ClientConfig {
@@ -47,6 +50,7 @@ impl ClientConfig {
         if self.local_addr.is_empty() {
             return Err(TunnelError::Config("local_addr is required".into()));
         }
+        validate_limits(&self.limits)?;
         Ok(())
     }
 }
@@ -60,6 +64,7 @@ impl Default for ClientConfig {
             tunnel_id: None,
             auto_reconnect: true,
             reconnect_delay: Duration::from_secs(5),
+            limits: LimitsConfig::default(),
         }
     }
 }
@@ -89,6 +94,9 @@ pub struct ServerConfig {
 
     /// Authentication token (clients must provide this)
     pub token: String,
+
+    /// Resource limits for protocol framing and connection handling.
+    pub limits: LimitsConfig,
 }
 
 impl ServerConfig {
@@ -97,6 +105,7 @@ impl ServerConfig {
         if self.token.is_empty() {
             return Err(TunnelError::Config("token is required".into()));
         }
+        validate_limits(&self.limits)?;
         #[cfg(feature = "http3")]
         if self.http3_bind_addr.is_some()
             && (self.http3_cert_path.is_none() || self.http3_key_path.is_none())
@@ -121,8 +130,23 @@ impl Default for ServerConfig {
             #[cfg(feature = "http3")]
             http3_key_path: None,
             token: String::new(),
+            limits: LimitsConfig::default(),
         }
     }
+}
+
+fn validate_limits(limits: &LimitsConfig) -> Result<()> {
+    if limits.max_frame_bytes == 0 {
+        return Err(TunnelError::Config(
+            "limits.max_frame_bytes must be greater than zero".into(),
+        ));
+    }
+    if limits.max_frame_bytes > u64::from(u32::MAX) {
+        return Err(TunnelError::Config(
+            "limits.max_frame_bytes must fit in the wire length prefix".into(),
+        ));
+    }
+    Ok(())
 }
 
 /// Information about an established tunnel connection.
@@ -150,6 +174,7 @@ mod tests {
         assert_eq!(config.local_addr, "127.0.0.1:8080");
         assert!(config.auto_reconnect);
         assert_eq!(config.reconnect_delay, Duration::from_secs(5));
+        assert_eq!(config.limits.max_frame_bytes, 16 * 1024 * 1024);
     }
 
     #[test]
@@ -161,6 +186,32 @@ mod tests {
             ..Default::default()
         };
         assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_client_config_validate_rejects_zero_frame_limit() {
+        let mut config = ClientConfig {
+            server_addr: "localhost:7835".to_string(),
+            token: "secret-token".to_string(),
+            local_addr: "127.0.0.1:8080".to_string(),
+            ..Default::default()
+        };
+        config.limits.max_frame_bytes = 0;
+        let err = config.validate().unwrap_err();
+        assert!(err.to_string().contains("max_frame_bytes"));
+    }
+
+    #[test]
+    fn test_client_config_validate_rejects_oversized_frame_limit() {
+        let mut config = ClientConfig {
+            server_addr: "localhost:7835".to_string(),
+            token: "secret-token".to_string(),
+            local_addr: "127.0.0.1:8080".to_string(),
+            ..Default::default()
+        };
+        config.limits.max_frame_bytes = u64::from(u32::MAX) + 1;
+        let err = config.validate().unwrap_err();
+        assert!(err.to_string().contains("wire length prefix"));
     }
 
     #[test]
@@ -208,6 +259,7 @@ mod tests {
             SocketAddr::from(([0, 0, 0, 0], 8080))
         );
         assert!(config.token.is_empty());
+        assert_eq!(config.limits.max_frame_bytes, 16 * 1024 * 1024);
     }
 
     #[test]
@@ -217,6 +269,28 @@ mod tests {
             ..Default::default()
         };
         assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_server_config_validate_rejects_zero_frame_limit() {
+        let mut config = ServerConfig {
+            token: "secret-token".to_string(),
+            ..Default::default()
+        };
+        config.limits.max_frame_bytes = 0;
+        let err = config.validate().unwrap_err();
+        assert!(err.to_string().contains("max_frame_bytes"));
+    }
+
+    #[test]
+    fn test_server_config_validate_rejects_oversized_frame_limit() {
+        let mut config = ServerConfig {
+            token: "secret-token".to_string(),
+            ..Default::default()
+        };
+        config.limits.max_frame_bytes = u64::from(u32::MAX) + 1;
+        let err = config.validate().unwrap_err();
+        assert!(err.to_string().contains("wire length prefix"));
     }
 
     #[test]

--- a/ferrotunnel/src/server.rs
+++ b/ferrotunnel/src/server.rs
@@ -18,8 +18,9 @@
 //! ```
 
 use crate::config::ServerConfig;
-use ferrotunnel_common::config::TlsConfig;
+use ferrotunnel_common::config::{LimitsConfig, TlsConfig};
 use ferrotunnel_common::{Result, TunnelError};
+use ferrotunnel_core::resource_limits::ServerResourceLimits;
 use ferrotunnel_core::transport::{tls::TlsTransportConfig, TransportConfig};
 use ferrotunnel_core::TunnelServer;
 use ferrotunnel_http::HttpIngress;
@@ -96,8 +97,16 @@ impl Server {
             info!("  HTTP/3 bind: {} (UDP)", http3_bind_addr);
         }
 
+        let tunnel_limits = config.limits.clone();
+        let resource_limits = ServerResourceLimits::new(
+            tunnel_limits.max_sessions,
+            tunnel_limits.max_streams_per_session,
+            tunnel_limits.max_inflight_frames,
+        );
         let tunnel_server = TunnelServer::new(config.bind_addr, config.token)
-            .with_transport(self.transport_config.clone());
+            .with_transport(self.transport_config.clone())
+            .with_limits(tunnel_limits)
+            .with_resource_limits(resource_limits);
 
         // Initialize plugins
         let mut registry = PluginRegistry::new();
@@ -121,6 +130,7 @@ impl Server {
                 .ok()
         });
 
+        #[cfg_attr(not(feature = "http3"), allow(unused_mut))]
         let mut ingress =
             HttpIngress::new(config.http_bind_addr, sessions.clone(), registry.clone());
         #[cfg(feature = "http3")]
@@ -320,6 +330,13 @@ impl ServerBuilder {
         self
     }
 
+    /// Configure resource limits.
+    #[must_use]
+    pub fn limits(mut self, limits: &LimitsConfig) -> Self {
+        self.config.limits = limits.clone();
+        self
+    }
+
     /// Configure QUIC transport for the server.
     ///
     /// When enabled, the server will accept QUIC connections for the tunnel control plane.
@@ -372,6 +389,10 @@ mod tests {
             .bind("0.0.0.0:9000".parse().unwrap())
             .http_bind("0.0.0.0:9001".parse().unwrap())
             .token("my-token")
+            .limits(&LimitsConfig {
+                max_frame_bytes: 4096,
+                ..Default::default()
+            })
             .build()
             .expect("should build successfully");
 
@@ -381,6 +402,7 @@ mod tests {
             "0.0.0.0:9001".parse().unwrap()
         );
         assert_eq!(server.config().token, "my-token");
+        assert_eq!(server.config().limits.max_frame_bytes, 4096);
     }
 
     #[test]


### PR DESCRIPTION
## What changed

- Added `TunnelCodec::from_limits(&LimitsConfig)` and route TCP/QUIC client and server codec construction through configured limits instead of always using `TunnelCodec::new()`.
- Added public client/server builder support for `LimitsConfig`, including validation for zero and wire-format oversized frame limits.
- Aligned `ValidationLimits` with `LimitsConfig` so validation and codec limits do not drift apart.
- Added codec/config tests that prove configured frame limits are applied and zero-sized codec limits are rejected.

## Why

`LimitsConfig::max_frame_bytes` defaulted to 16 MB, but production codec construction ignored it. That meant callers could configure a smaller frame limit and still get the default codec behavior. Threading the same limit into the codec makes the configuration enforceable at the frame boundary, which is the first place oversized frames should be rejected.

I also reject limits larger than the `u32` wire length prefix can represent. That keeps the API honest: if a frame size cannot be encoded on the wire, it should fail during configuration rather than silently accepting an impossible value.

Fixes #144.

## Validation

- `cargo test -p ferrotunnel-protocol`
- `make check`
- `make test`
