### PR TITLE
fix: supervise server lifecycle task

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,9 @@ async fn main() -> ferrotunnel::Result<()> {
         .token("my-secret-token")
         .build()?;
 
-    server.start().await
+    server.start().await?;
+    tokio::signal::ctrl_c().await?;
+    server.shutdown().await
 }
 ```
 

--- a/ferrotunnel/README.md
+++ b/ferrotunnel/README.md
@@ -65,7 +65,9 @@ async fn main() -> ferrotunnel::Result<()> {
         .token("my-token")
         .build()?;
 
-    server.start().await
+    server.start().await?;
+    tokio::signal::ctrl_c().await?;
+    server.shutdown().await
 }
 ```
 

--- a/ferrotunnel/src/lib.rs
+++ b/ferrotunnel/src/lib.rs
@@ -49,6 +49,8 @@
 //!         .build()?;
 //!
 //!     server.start().await?;
+//!     tokio::signal::ctrl_c().await?;
+//!     server.shutdown().await?;
 //!     Ok(())
 //! }
 //! ```

--- a/ferrotunnel/src/server.rs
+++ b/ferrotunnel/src/server.rs
@@ -13,6 +13,8 @@
 //!     .build()?;
 //!
 //! server.start().await?;
+//! tokio::signal::ctrl_c().await?;
+//! server.shutdown().await?;
 //! # Ok(())
 //! # }
 //! ```
@@ -70,24 +72,41 @@ impl Server {
         ServerBuilder::default()
     }
 
-    /// Start the tunnel server.
+    /// Start the tunnel server in the background.
     ///
-    /// This will bind to the configured addresses and start accepting connections.
-    /// The server runs until [`shutdown()`](Self::shutdown) is called.
+    /// This launches the configured tunnel and ingress services. The server runs until
+    /// [`shutdown()`](Self::shutdown) or [`stop()`](Self::stop) is called, or until one
+    /// of the service tasks exits.
     ///
     /// # Errors
     ///
     /// Returns an error if the server is already running.
-    #[allow(clippy::too_many_lines)]
     pub async fn start(&mut self) -> Result<()> {
-        if self.task.is_some() {
+        if self.is_running() {
             return Err(TunnelError::InvalidState("server already started".into()));
+        }
+        if let Some(task) = self.task.take() {
+            let _ = task.await;
         }
 
         let config = self.config.clone();
-        let (shutdown_tx, mut shutdown_rx) = watch::channel(false);
+        let transport_config = self.transport_config.clone();
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
         self.shutdown_tx = Some(shutdown_tx);
 
+        self.task = Some(tokio::spawn(async move {
+            Self::run_services(config, transport_config, shutdown_rx).await
+        }));
+
+        Ok(())
+    }
+
+    #[allow(clippy::too_many_lines)]
+    async fn run_services(
+        config: ServerConfig,
+        transport_config: TransportConfig,
+        mut shutdown_rx: watch::Receiver<bool>,
+    ) -> Result<()> {
         info!("Starting `FerroTunnel` Server");
         info!("  Tunnel bind: {}", config.bind_addr);
         info!("  HTTP bind: {}", config.http_bind_addr);
@@ -96,8 +115,10 @@ impl Server {
             info!("  HTTP/3 bind: {} (UDP)", http3_bind_addr);
         }
 
-        let tunnel_server = TunnelServer::new(config.bind_addr, config.token)
-            .with_transport(self.transport_config.clone());
+        #[cfg(feature = "quic")]
+        let tunnel_transport = transport_config.clone();
+        let tunnel_server =
+            TunnelServer::new(config.bind_addr, config.token).with_transport(transport_config);
 
         // Initialize plugins
         let mut registry = PluginRegistry::new();
@@ -130,8 +151,7 @@ impl Server {
 
         // Spawn both services
         #[cfg(feature = "quic")]
-        let tunnel_handle = {
-            let tunnel_transport = self.transport_config.clone();
+        let mut tunnel_handle = {
             let tunnel_bind_addr = config.bind_addr;
             tokio::spawn(async move {
                 if matches!(tunnel_transport, TransportConfig::Quic(_)) {
@@ -142,8 +162,8 @@ impl Server {
             })
         };
         #[cfg(not(feature = "quic"))]
-        let tunnel_handle = tokio::spawn(async move { tunnel_server.run().await });
-        let ingress_handle = tokio::spawn(async move { ingress.start().await });
+        let mut tunnel_handle = tokio::spawn(async move { tunnel_server.run().await });
+        let mut ingress_handle = tokio::spawn(async move { ingress.start().await });
 
         #[cfg(feature = "http3")]
         let http3_handle = if let Some(http3_bind_addr) = config.http3_bind_addr {
@@ -170,52 +190,57 @@ impl Server {
 
         // Wait for shutdown or either service to exit
         #[cfg(feature = "http3")]
-        if let Some(http3_handle) = http3_handle {
-            tokio::select! {
-                result = tunnel_handle => {
-                    match result {
-                        Ok(inner) => inner?,
-                        Err(e) => return Err(TunnelError::Connection(format!("Tunnel task panicked: {e}"))),
-                    }
+        if let Some(mut http3_handle) = http3_handle {
+            let result = tokio::select! {
+                result = &mut tunnel_handle => Self::service_result("Tunnel", result),
+                result = &mut ingress_handle => Self::service_result("Ingress", result),
+                result = &mut http3_handle => Self::service_result("HTTP/3 ingress", result),
+                changed = shutdown_rx.changed() => {
+                    Self::log_shutdown_result(&changed);
+                    Ok(())
                 }
-                result = ingress_handle => {
-                    match result {
-                        Ok(inner) => inner?,
-                        Err(e) => return Err(TunnelError::Connection(format!("Ingress task panicked: {e}"))),
-                    }
-                }
-                result = http3_handle => {
-                    match result {
-                        Ok(inner) => inner?,
-                        Err(e) => return Err(TunnelError::Connection(format!("HTTP/3 ingress task panicked: {e}"))),
-                    }
-                }
-                _ = shutdown_rx.changed() => {
-                    info!("Server shutdown requested");
-                }
-            }
-            return Ok(());
+            };
+            tunnel_handle.abort();
+            ingress_handle.abort();
+            http3_handle.abort();
+            return result;
         }
 
-        tokio::select! {
-            result = tunnel_handle => {
-                match result {
-                    Ok(inner) => inner?,
-                    Err(e) => return Err(TunnelError::Connection(format!("Tunnel task panicked: {e}"))),
-                }
+        let result = tokio::select! {
+            result = &mut tunnel_handle => Self::service_result("Tunnel", result),
+            result = &mut ingress_handle => Self::service_result("Ingress", result),
+            changed = shutdown_rx.changed() => {
+                Self::log_shutdown_result(&changed);
+                Ok(())
             }
-            result = ingress_handle => {
-                match result {
-                    Ok(inner) => inner?,
-                    Err(e) => return Err(TunnelError::Connection(format!("Ingress task panicked: {e}"))),
-                }
-            }
-            _ = shutdown_rx.changed() => {
+        };
+        tunnel_handle.abort();
+        ingress_handle.abort();
+
+        result
+    }
+
+    fn service_result(
+        name: &str,
+        result: std::result::Result<Result<()>, tokio::task::JoinError>,
+    ) -> Result<()> {
+        match result {
+            Ok(inner) => inner,
+            Err(e) => Err(TunnelError::Connection(format!(
+                "{name} task panicked: {e}"
+            ))),
+        }
+    }
+
+    fn log_shutdown_result(changed: &std::result::Result<(), watch::error::RecvError>) {
+        match changed {
+            Ok(()) => {
                 info!("Server shutdown requested");
             }
+            Err(_) => {
+                info!("Server shutdown channel closed");
+            }
         }
-
-        Ok(())
     }
 
     /// Shutdown the tunnel server and wait for cleanup.
@@ -226,7 +251,14 @@ impl Server {
             let _ = tx.send(true);
         }
         if let Some(task) = self.task.take() {
-            let _ = task.await;
+            match task.await {
+                Ok(result) => result?,
+                Err(e) => {
+                    return Err(TunnelError::Connection(format!(
+                        "Server task panicked: {e}"
+                    )));
+                }
+            }
         }
         Ok(())
     }
@@ -245,7 +277,7 @@ impl Server {
         if let Some(task) = &self.task {
             !task.is_finished()
         } else {
-            self.shutdown_tx.is_some()
+            false
         }
     }
 
@@ -416,6 +448,28 @@ mod tests {
             .build()
             .expect("should build");
 
+        assert!(!server.is_running());
+    }
+
+    #[tokio::test]
+    async fn test_server_start_shutdown_lifecycle() {
+        let mut server = Server::builder()
+            .bind("127.0.0.1:0".parse().unwrap())
+            .http_bind("127.0.0.1:0".parse().unwrap())
+            .token("secret")
+            .build()
+            .expect("should build");
+
+        server.start().await.expect("server should start");
+        assert!(server.is_running());
+
+        let err = server
+            .start()
+            .await
+            .expect_err("second start should fail while running");
+        assert!(err.to_string().contains("already started"));
+
+        server.shutdown().await.expect("server should shut down");
         assert!(!server.is_running());
     }
 

--- a/tests/integration/concurrent_test.rs
+++ b/tests/integration/concurrent_test.rs
@@ -1,7 +1,7 @@
 //! Concurrency integration tests
 
-use super::{start_echo_server, wait_for_server, TestConfig};
-use ferrotunnel::{Client, Server};
+use super::{start_echo_server, start_test_server, TestConfig};
+use ferrotunnel::Client;
 use std::sync::{
     atomic::{AtomicUsize, Ordering},
     Arc,
@@ -16,19 +16,7 @@ async fn test_concurrent_requests() {
     // Start local echo service
     let _echo_handle = start_echo_server(config.local_service_addr).await;
 
-    // Start server
-    let mut server = Server::builder()
-        .bind(config.server_addr)
-        .http_bind(config.http_addr)
-        .token(config.token)
-        .build()
-        .expect("Failed to build server");
-
-    let _server_handle = tokio::spawn(async move {
-        let _ = server.start().await;
-    });
-
-    assert!(wait_for_server(config.server_addr, Duration::from_secs(5)).await);
+    let mut server = start_test_server(&config).await;
 
     // Start client
     let mut client = Client::builder()
@@ -81,4 +69,5 @@ async fn test_concurrent_requests() {
     );
 
     let _ = client.shutdown().await;
+    let _ = server.shutdown().await;
 }

--- a/tests/integration/error_test.rs
+++ b/tests/integration/error_test.rs
@@ -1,7 +1,7 @@
 //! Error scenario integration tests
 
-use super::{wait_for_server, TestConfig};
-use ferrotunnel::{Client, Server};
+use super::{start_test_server, TestConfig};
+use ferrotunnel::Client;
 use std::time::Duration;
 
 /// Test upstream connection refused (tunnel -> local service fails)
@@ -11,19 +11,7 @@ async fn test_upstream_connection_refused() {
 
     // Do NOT start local service -> Connection refused
 
-    // Start server
-    let mut server = Server::builder()
-        .bind(config.server_addr)
-        .http_bind(config.http_addr)
-        .token(config.token)
-        .build()
-        .expect("Failed to build server");
-
-    let _server_handle = tokio::spawn(async move {
-        let _ = server.start().await;
-    });
-
-    assert!(wait_for_server(config.server_addr, Duration::from_secs(5)).await);
+    let mut server = start_test_server(&config).await;
 
     // Start client
     let mut client = Client::builder()
@@ -53,6 +41,7 @@ async fn test_upstream_connection_refused() {
     assert_eq!(response.status(), 502);
 
     let _ = client.shutdown().await;
+    let _ = server.shutdown().await;
 }
 
 /// Test upstream timeout

--- a/tests/integration/grpc_test.rs
+++ b/tests/integration/grpc_test.rs
@@ -95,9 +95,7 @@ async fn test_grpc_tunnel() {
         .build()
         .expect("Failed to build server");
 
-    let _server_handle = tokio::spawn(async move {
-        let _ = server.start().await;
-    });
+    server.start().await.expect("Failed to start server");
 
     assert!(
         wait_for_server(server_addr, Duration::from_secs(5)).await,
@@ -189,6 +187,9 @@ async fn test_grpc_tunnel() {
         Some("0"),
         "Expected grpc-status: 0 trailer to be preserved through the tunnel"
     );
+
+    let _ = client.shutdown().await;
+    let _ = server.shutdown().await;
 }
 
 /// Verifies that ordinary HTTP/1.1 requests are NOT classified as gRPC
@@ -240,9 +241,7 @@ async fn test_non_grpc_not_classified_as_grpc() {
         .build()
         .expect("Failed to build server");
 
-    let _server_handle = tokio::spawn(async move {
-        let _ = server.start().await;
-    });
+    server.start().await.expect("Failed to start server");
 
     assert!(
         wait_for_server(server_addr, Duration::from_secs(5)).await,
@@ -287,4 +286,7 @@ async fn test_non_grpc_not_classified_as_grpc() {
         ct, "text/plain",
         "Expected text/plain, not gRPC content-type"
     );
+
+    let _ = client.shutdown().await;
+    let _ = server.shutdown().await;
 }

--- a/tests/integration/http3_test.rs
+++ b/tests/integration/http3_test.rs
@@ -84,7 +84,7 @@ async fn test_http3_request_through_tunnel_and_alt_svc_advertised() {
         .token(token)
         .build()
         .expect("Failed to build HTTP/3 server");
-    let server_handle = tokio::spawn(async move { server.start().await });
+    server.start().await.expect("Failed to start server");
 
     assert!(
         wait_for_server(context.server_addr, Duration::from_secs(5)).await,
@@ -129,7 +129,7 @@ async fn test_http3_request_through_tunnel_and_alt_svc_advertised() {
     assert!(body.contains("Hello, World!"));
 
     let _ = client.shutdown().await;
-    server_handle.abort();
+    let _ = server.shutdown().await;
 }
 
 #[tokio::test]
@@ -150,7 +150,7 @@ async fn test_http3_unknown_host_returns_not_found() {
         .token("test-http3-token")
         .build()
         .expect("Failed to build HTTP/3 server");
-    let server_handle = tokio::spawn(async move { server.start().await });
+    server.start().await.expect("Failed to start server");
 
     assert!(
         wait_for_server(context.server_addr, Duration::from_secs(5)).await,
@@ -162,7 +162,7 @@ async fn test_http3_unknown_host_returns_not_found() {
     assert_eq!(status, http::StatusCode::NOT_FOUND);
     assert_eq!(body, "Tunnel not found");
 
-    server_handle.abort();
+    let _ = server.shutdown().await;
 }
 
 async fn send_h3_get(

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -69,6 +69,23 @@ pub async fn wait_for_server(addr: SocketAddr, timeout: Duration) -> bool {
     false
 }
 
+pub async fn start_test_server(config: &TestConfig) -> ferrotunnel::Server {
+    let mut server = ferrotunnel::Server::builder()
+        .bind(config.server_addr)
+        .http_bind(config.http_addr)
+        .token(config.token)
+        .build()
+        .expect("Failed to build server");
+
+    server.start().await.expect("Failed to start server");
+    assert!(
+        wait_for_server(config.server_addr, Duration::from_secs(5)).await,
+        "Server did not start in time"
+    );
+
+    server
+}
+
 /// Start a simple HTTP server that echoes requests
 pub async fn start_echo_server(addr: SocketAddr) -> tokio::task::JoinHandle<()> {
     use tokio::io::{AsyncReadExt, AsyncWriteExt};

--- a/tests/integration/multi_client_test.rs
+++ b/tests/integration/multi_client_test.rs
@@ -2,8 +2,8 @@
 //!
 //! Tests scenarios with multiple concurrent tunnel clients
 
-use super::{start_echo_server, wait_for_server, TestConfig};
-use ferrotunnel::{Client, Server};
+use super::{start_echo_server, start_test_server, TestConfig};
+use ferrotunnel::Client;
 use std::time::Duration;
 
 /// Test multiple clients connecting to same server
@@ -19,20 +19,7 @@ async fn test_multiple_clients() {
     let _echo1 = start_echo_server(config.local_service_addr).await;
     let _echo2 = start_echo_server(local_addr2.parse().unwrap()).await;
 
-    // Start server
-    let mut server = Server::builder()
-        .bind(config.server_addr)
-        .http_bind(config.http_addr)
-        .token(config.token)
-        .build()
-        .expect("Failed to build server");
-
-    let _server_handle = tokio::spawn(async move {
-        let _ = server.start().await;
-    });
-
-    // Wait for server
-    assert!(wait_for_server(config.server_addr, Duration::from_secs(5)).await);
+    let mut server = start_test_server(&config).await;
 
     // Start first client
     let mut client1 = Client::builder()
@@ -63,6 +50,7 @@ async fn test_multiple_clients() {
     // Cleanup
     let _ = client1.shutdown().await;
     let _ = client2.shutdown().await;
+    let _ = server.shutdown().await;
 }
 
 /// Test client reconnection behavior
@@ -73,19 +61,7 @@ async fn test_client_reconnect() {
     // Start local service
     let _echo = start_echo_server(config.local_service_addr).await;
 
-    // Start server
-    let mut server = Server::builder()
-        .bind(config.server_addr)
-        .http_bind(config.http_addr)
-        .token(config.token)
-        .build()
-        .expect("Failed to build server");
-
-    let _server_handle = tokio::spawn(async move {
-        let _ = server.start().await;
-    });
-
-    assert!(wait_for_server(config.server_addr, Duration::from_secs(5)).await);
+    let mut server = start_test_server(&config).await;
 
     // First connection
     let mut client = Client::builder()
@@ -121,4 +97,5 @@ async fn test_client_reconnect() {
     );
 
     let _ = client2.shutdown().await;
+    let _ = server.shutdown().await;
 }

--- a/tests/integration/quic_test.rs
+++ b/tests/integration/quic_test.rs
@@ -219,7 +219,7 @@ async fn test_public_api_quic_routing() {
         .build()
         .expect("Failed to build QUIC server");
 
-    let server_handle = tokio::spawn(async move { server.start().await });
+    server.start().await.expect("Failed to start server");
 
     assert!(
         wait_for_quic_server(quic_addr, &cert_path, Duration::from_secs(5)).await,
@@ -262,6 +262,6 @@ async fn test_public_api_quic_routing() {
     assert!(text.contains("Hello, World!"));
 
     let _ = client.shutdown().await;
-    server_handle.abort();
+    let _ = server.shutdown().await;
     let _ = std::fs::remove_dir_all(temp_dir);
 }

--- a/tests/integration/tls_test.rs
+++ b/tests/integration/tls_test.rs
@@ -55,9 +55,7 @@ async fn test_tls_connection() {
         .build()
         .expect("Failed to build server");
 
-    let _server_handle = tokio::spawn(async move {
-        let _ = server.start().await;
-    });
+    server.start().await.expect("Failed to start server");
 
     // Wait for server? (Should we check TCP connect?)
     // But plain TCP connect might hang on handshake if we don't speak TLS?
@@ -91,5 +89,6 @@ async fn test_tls_connection() {
 
     // Clean up
     let _ = client.shutdown().await;
+    let _ = server.shutdown().await;
     let _ = std::fs::remove_dir_all(temp_dir);
 }

--- a/tests/integration/tunnel_test.rs
+++ b/tests/integration/tunnel_test.rs
@@ -2,7 +2,7 @@
 //!
 //! Tests basic tunnel functionality: server, client, HTTP routing
 
-use super::{start_echo_server, wait_for_server, TestConfig};
+use super::{start_echo_server, start_test_server, TestConfig};
 use ferrotunnel::{Client, Server};
 use std::time::Duration;
 
@@ -18,17 +18,10 @@ async fn test_server_starts() {
         .build()
         .expect("Failed to build server");
 
-    // Start server in background
-    let server_handle = tokio::spawn(async move { server.start().await });
-
-    // Wait for server to be ready
-    assert!(
-        wait_for_server(config.server_addr, Duration::from_secs(5)).await,
-        "Server did not start in time"
-    );
-
-    // Clean up
-    server_handle.abort();
+    server.start().await.expect("Failed to start server");
+    assert!(server.is_running());
+    server.shutdown().await.expect("Failed to stop server");
+    assert!(!server.is_running());
 }
 
 /// Test that client connects to server
@@ -39,23 +32,7 @@ async fn test_client_connects() {
     // Start local service
     let _echo_handle = start_echo_server(config.local_service_addr).await;
 
-    // Start server
-    let mut server = Server::builder()
-        .bind(config.server_addr)
-        .http_bind(config.http_addr)
-        .token(config.token)
-        .build()
-        .expect("Failed to build server");
-
-    let _server_handle = tokio::spawn(async move {
-        let _ = server.start().await;
-    });
-
-    // Wait for server
-    assert!(
-        wait_for_server(config.server_addr, Duration::from_secs(5)).await,
-        "Server did not start"
-    );
+    let mut server = start_test_server(&config).await;
 
     // Build and start client
     let mut client = Client::builder()
@@ -77,6 +54,7 @@ async fn test_client_connects() {
 
     // Shutdown
     let _ = client.shutdown().await;
+    let _ = server.shutdown().await;
 }
 
 /// Test full HTTP request through tunnel
@@ -87,20 +65,7 @@ async fn test_http_through_tunnel() {
     // Start local echo service
     let _echo_handle = start_echo_server(config.local_service_addr).await;
 
-    // Start server
-    let mut server = Server::builder()
-        .bind(config.server_addr)
-        .http_bind(config.http_addr)
-        .token(config.token)
-        .build()
-        .expect("Failed to build server");
-
-    let _server_handle = tokio::spawn(async move {
-        let _ = server.start().await;
-    });
-
-    // Wait for server
-    assert!(wait_for_server(config.server_addr, Duration::from_secs(5)).await);
+    let mut server = start_test_server(&config).await;
 
     // Start client
     let mut client = Client::builder()
@@ -143,6 +108,7 @@ async fn test_http_through_tunnel() {
     );
 
     let _ = client.shutdown().await;
+    let _ = server.shutdown().await;
 }
 
 /// Test large payload handling
@@ -153,19 +119,7 @@ async fn test_large_payload() {
     // Start local sink service that reads everything and replies OK
     let _sink_handle = super::start_sink_server(config.local_service_addr).await;
 
-    // Start server
-    let mut server = Server::builder()
-        .bind(config.server_addr)
-        .http_bind(config.http_addr)
-        .token(config.token)
-        .build()
-        .expect("Failed to build server");
-
-    let _server_handle = tokio::spawn(async move {
-        let _ = server.start().await;
-    });
-
-    assert!(wait_for_server(config.server_addr, Duration::from_secs(5)).await);
+    let mut server = start_test_server(&config).await;
 
     // Start client
     let mut client = Client::builder()
@@ -205,4 +159,5 @@ async fn test_large_payload() {
     );
 
     let _ = client.shutdown().await;
+    let _ = server.shutdown().await;
 }

--- a/tests/integration/websocket_test.rs
+++ b/tests/integration/websocket_test.rs
@@ -54,9 +54,7 @@ async fn test_websocket_upgrade_through_tunnel() {
         .build()
         .expect("Failed to build server");
 
-    let _server_handle = tokio::spawn(async move {
-        let _ = server.start().await;
-    });
+    server.start().await.expect("Failed to start server");
 
     assert!(
         wait_for_server(server_addr, Duration::from_secs(5)).await,
@@ -130,6 +128,7 @@ async fn test_websocket_upgrade_through_tunnel() {
     drop(read);
 
     let _ = client.shutdown().await;
+    let _ = server.shutdown().await;
 }
 
 #[tokio::test]
@@ -151,9 +150,7 @@ async fn test_websocket_raw_upgrade_101() {
         .build()
         .expect("Failed to build server");
 
-    let _server_handle = tokio::spawn(async move {
-        let _ = server.start().await;
-    });
+    server.start().await.expect("Failed to start server");
 
     assert!(
         wait_for_server(server_addr, Duration::from_secs(5)).await,
@@ -210,6 +207,7 @@ async fn test_websocket_raw_upgrade_101() {
     );
 
     let _ = client.shutdown().await;
+    let _ = server.shutdown().await;
 }
 
 #[allow(clippy::result_large_err, clippy::unnecessary_wraps)]
@@ -260,9 +258,7 @@ async fn test_websocket_subprotocol_preserved() {
         .build()
         .expect("Failed to build server");
 
-    let _server_handle = tokio::spawn(async move {
-        let _ = server.start().await;
-    });
+    server.start().await.expect("Failed to start server");
 
     wait_for_server(server_addr, Duration::from_secs(5)).await;
 
@@ -293,6 +289,7 @@ async fn test_websocket_subprotocol_preserved() {
     assert_eq!(response.status(), http::StatusCode::SWITCHING_PROTOCOLS);
 
     let _ = client.shutdown().await;
+    let _ = server.shutdown().await;
 }
 
 #[tokio::test]
@@ -314,9 +311,7 @@ async fn test_websocket_multiple_concurrent_streams() {
         .build()
         .expect("Failed to build server");
 
-    let _server_handle = tokio::spawn(async move {
-        let _ = server.start().await;
-    });
+    server.start().await.expect("Failed to start server");
 
     wait_for_server(server_addr, Duration::from_secs(5)).await;
 
@@ -365,6 +360,7 @@ async fn test_websocket_multiple_concurrent_streams() {
     }
 
     let _ = client.shutdown().await;
+    let _ = server.shutdown().await;
 }
 
 #[tokio::test]
@@ -407,9 +403,7 @@ async fn test_websocket_failed_upgrade_404() {
         .build()
         .expect("Failed to build server");
 
-    let _server_handle = tokio::spawn(async move {
-        let _ = server.start().await;
-    });
+    server.start().await.expect("Failed to start server");
 
     wait_for_server(server_addr, Duration::from_secs(5)).await;
 
@@ -442,4 +436,5 @@ async fn test_websocket_failed_upgrade_404() {
     }
 
     let _ = client.shutdown().await;
+    let _ = server.shutdown().await;
 }


### PR DESCRIPTION
## What changed

- Make `Server::start()` launch the tunnel/ingress services in a stored background supervisor task instead of awaiting the service loop inline.
- Make `Server::shutdown()` signal that supervisor and await its result, so shutdown errors or task panics are not silently discarded.
- Make `Server::is_running()` reflect the real `JoinHandle` liveness and make the double-start guard reachable.
- Abort sibling service tasks when shutdown is requested or when one service exits.
- Update examples/docs to show the now non-blocking `start()` lifecycle and explicit shutdown.
- Update integration tests to retain the public `Server` handle and shut it down explicitly.

## Why

The public `Server` type already carried `task` and `shutdown_tx` fields, but `start()` never assigned `self.task`; it ran the service `select!` directly. That made the lifecycle API inconsistent: `shutdown()` had no stored server task to wait on, `is_running()` could report from stale state, and the double-start guard was effectively dead for real running servers.

This keeps the existing API shape but makes the lifecycle state authoritative: the server is considered running only while the stored supervisor task is alive, and shutdown waits for the same task that owns the service loop.

Fixes #120.

## Validation

- `make check`
- `make test`
