### PR TITLE
fix: warn on disabled certificate verification

### DIFF
--- a/ferrotunnel-common/src/config.rs
+++ b/ferrotunnel-common/src/config.rs
@@ -18,6 +18,12 @@ pub struct TlsConfig {
     pub server_name: Option<String>,
     /// Require client certificate authentication
     pub client_auth: bool,
+    /// Skip certificate verification (insecure, for self-signed certs only).
+    ///
+    /// Enabling this leaves TLS connections unauthenticated and vulnerable to
+    /// man-in-the-middle interception. Client config builders emit a warning
+    /// whenever this is used.
+    pub skip_verify: bool,
 }
 
 /// Resource limits configuration
@@ -93,6 +99,10 @@ pub struct QuicConfig {
     pub max_idle_timeout_secs: Option<u64>,
     /// Keep-alive interval in seconds (default: 10)
     pub keep_alive_interval_secs: Option<u64>,
-    /// Skip certificate verification (insecure, for self-signed certs)
+    /// Skip certificate verification (insecure, for self-signed certs only).
+    ///
+    /// Enabling this leaves QUIC connections unauthenticated and vulnerable to
+    /// man-in-the-middle interception. Client config builders emit a warning
+    /// whenever this is used.
     pub skip_verify: bool,
 }

--- a/ferrotunnel-core/src/transport/quic.rs
+++ b/ferrotunnel-core/src/transport/quic.rs
@@ -90,6 +90,13 @@ impl QuicTransportConfig {
 
 /// Create a quinn `ClientConfig` by reusing the existing rustls TLS config infrastructure.
 pub fn create_quinn_client_config(config: &QuicTransportConfig) -> io::Result<ClientConfig> {
+    create_quinn_client_config_with_target(config, config.server_name.as_deref())
+}
+
+fn create_quinn_client_config_with_target(
+    config: &QuicTransportConfig,
+    server_name: Option<&str>,
+) -> io::Result<ClientConfig> {
     // Reuse TLS config creation from tls.rs
     let tls_config = tls::TlsTransportConfig {
         ca_cert_path: config.ca_cert_path.clone(),
@@ -100,7 +107,7 @@ pub fn create_quinn_client_config(config: &QuicTransportConfig) -> io::Result<Cl
         skip_verify: config.skip_verify,
     };
 
-    let rustls_config = tls::create_client_config(&tls_config)?;
+    let rustls_config = tls::create_client_config_with_context(&tls_config, "QUIC", server_name)?;
 
     let mut transport = quinn::TransportConfig::default();
     transport.max_idle_timeout(Some(config.max_idle_timeout.try_into().map_err(|e| {
@@ -152,7 +159,14 @@ pub fn create_quinn_server_config(config: &QuicTransportConfig) -> io::Result<Se
 
 /// Create a client endpoint bound to an ephemeral UDP port.
 pub fn create_client_endpoint(config: &QuicTransportConfig) -> io::Result<Endpoint> {
-    let client_config = create_quinn_client_config(config)?;
+    create_client_endpoint_with_target(config, config.server_name.as_deref())
+}
+
+fn create_client_endpoint_with_target(
+    config: &QuicTransportConfig,
+    server_name: Option<&str>,
+) -> io::Result<Endpoint> {
+    let client_config = create_quinn_client_config_with_target(config, server_name)?;
     let mut endpoint = Endpoint::client(
         "0.0.0.0:0"
             .parse()
@@ -180,8 +194,6 @@ pub async fn connect(
     addr: &str,
     config: &QuicTransportConfig,
 ) -> io::Result<(Endpoint, quinn::Connection)> {
-    let endpoint = create_client_endpoint(config)?;
-
     let (host, port) = split_host_port(addr)?;
     let socket_addr = tokio::net::lookup_host((host.as_str(), port))
         .await?
@@ -189,6 +201,7 @@ pub async fn connect(
         .ok_or_else(|| io::Error::new(ErrorKind::AddrNotAvailable, "address resolution failed"))?;
 
     let server_name = config.server_name.clone().unwrap_or(host);
+    let endpoint = create_client_endpoint_with_target(config, Some(&server_name))?;
 
     // Validate server name
     let _: ServerName<'_> = ServerName::try_from(server_name.as_str()).map_err(|e| {

--- a/ferrotunnel-core/src/transport/tls.rs
+++ b/ferrotunnel-core/src/transport/tls.rs
@@ -46,7 +46,7 @@ impl TlsTransportConfig {
                 .unwrap_or_default(),
             server_name: config.server_name.clone(),
             client_auth: config.client_auth,
-            skip_verify: false,
+            skip_verify: config.skip_verify,
         })
     }
 }
@@ -113,9 +113,18 @@ impl rustls::client::danger::ServerCertVerifier for InsecureServerCertVerifier {
 }
 
 pub fn create_client_config(config: &TlsTransportConfig) -> io::Result<Arc<ClientConfig>> {
+    create_client_config_with_context(config, "TLS", config.server_name.as_deref())
+}
+
+pub(crate) fn create_client_config_with_context(
+    config: &TlsTransportConfig,
+    transport: &'static str,
+    server_name: Option<&str>,
+) -> io::Result<Arc<ClientConfig>> {
     let builder = ClientConfig::builder();
 
     let builder = if config.skip_verify {
+        warn_insecure_verification(transport, server_name);
         builder
             .dangerous()
             .with_custom_certificate_verifier(Arc::new(InsecureServerCertVerifier))
@@ -148,6 +157,15 @@ pub fn create_client_config(config: &TlsTransportConfig) -> io::Result<Arc<Clien
     };
 
     Ok(Arc::new(client_config))
+}
+
+fn warn_insecure_verification(transport: &'static str, server_name: Option<&str>) {
+    let server_name = server_name.unwrap_or("<runtime server name>");
+    tracing::warn!(
+        transport,
+        server_name,
+        "certificate verification is disabled; peer identity will not be authenticated"
+    );
 }
 
 pub fn create_server_config(config: &TlsTransportConfig) -> io::Result<Arc<ServerConfig>> {
@@ -190,19 +208,23 @@ pub fn create_server_config(config: &TlsTransportConfig) -> io::Result<Arc<Serve
 }
 
 pub async fn connect(addr: &str, config: &TlsTransportConfig) -> io::Result<BoxedStream> {
-    let client_config = create_client_config(config)?;
+    let configured_server_name = config.server_name.is_some();
+    let server_name = config
+        .server_name
+        .clone()
+        .unwrap_or_else(|| addr.split(':').next().unwrap_or("localhost").to_string());
+    let client_config = create_client_config_with_context(config, "TLS", Some(&server_name))?;
     let connector = TlsConnector::from(client_config);
 
     let tcp_stream = TcpStream::connect(addr).await?;
     configure_socket_silent(&tcp_stream);
 
-    let server_name = if let Some(name) = &config.server_name {
-        ServerName::try_from(name.clone()).map_err(|e| {
+    let server_name = if configured_server_name {
+        ServerName::try_from(server_name).map_err(|e| {
             io::Error::new(ErrorKind::InvalidInput, format!("invalid server name: {e}"))
         })?
     } else {
-        let host = addr.split(':').next().unwrap_or("localhost");
-        ServerName::try_from(host.to_string()).map_err(|e| {
+        ServerName::try_from(server_name).map_err(|e| {
             io::Error::new(
                 ErrorKind::InvalidInput,
                 format!("invalid host in address '{}': {}", addr, e),
@@ -221,4 +243,25 @@ pub async fn accept_tls(
     let server_config = create_server_config(config)?;
     let acceptor = TlsAcceptor::from(server_config);
     acceptor.accept(tcp_stream).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::TlsTransportConfig;
+    use ferrotunnel_common::config::TlsConfig;
+
+    #[test]
+    fn from_common_preserves_skip_verify() {
+        let config = TlsConfig {
+            enabled: true,
+            skip_verify: true,
+            server_name: Some("localhost".to_string()),
+            ..Default::default()
+        };
+
+        let tls = TlsTransportConfig::from_common(&config).expect("TLS should be enabled");
+
+        assert!(tls.skip_verify);
+        assert_eq!(tls.server_name.as_deref(), Some("localhost"));
+    }
 }


### PR DESCRIPTION
## What changed

- Add `TlsConfig::skip_verify` so common TLS config is symmetric with `QuicConfig::skip_verify`.
- Preserve that flag when building `TlsTransportConfig` from common config.
- Emit a `tracing::warn!` whenever TLS or QUIC client config is built with certificate verification disabled.
- Thread the runtime server name into the TLS/QUIC warning path when the connection helper can derive it from the address.
- Document the security impact directly on both common config fields.
- Add coverage that common TLS config preserves `skip_verify` into the transport config.

## Why

`skip_verify` can be useful for local/self-signed setups, but it changes a core security invariant: the peer is no longer authenticated, so MITM protection is not provided. Previously the rustls insecure verifier could be installed silently, and the common TLS config did not expose the same skip-verify knob that QUIC already had.

This keeps the escape hatch available, but makes it explicit in logs and ensures both TLS and QUIC config paths carry/document the same risk.

Fixes #143.

## Validation

- `make check`
- `make test`
