### PR TITLE
fix: make metrics initialization panic-free

### DIFF
--- a/ferrotunnel-cli/src/commands/server.rs
+++ b/ferrotunnel-cli/src/commands/server.rs
@@ -106,9 +106,33 @@ pub async fn run(args: ServerArgs) -> Result<()> {
         // Start metrics endpoint in background (only when metrics is enabled)
         let metrics_addr = args.metrics_bind;
         tokio::spawn(async move {
-            use axum::{routing::get, Router};
+            use axum::{
+                http::StatusCode,
+                response::{IntoResponse, Response},
+                routing::get,
+                Router,
+            };
+            async fn metrics_response() -> Response {
+                match gather_metrics() {
+                    Ok(metrics) => (
+                        StatusCode::OK,
+                        [("content-type", "text/plain; charset=utf-8")],
+                        metrics,
+                    )
+                        .into_response(),
+                    Err(error) => {
+                        tracing::error!(%error, "failed to gather metrics");
+                        (
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                            "failed to gather metrics\n",
+                        )
+                            .into_response()
+                    }
+                }
+            }
+
             let app = Router::new()
-                .route("/metrics", get(|| async { gather_metrics() }))
+                .route("/metrics", get(metrics_response))
                 .route("/health/ready", get(|| async { "OK" }));
             info!("Metrics server listening on http://{}", metrics_addr);
             match tokio::net::TcpListener::bind(metrics_addr).await {

--- a/ferrotunnel-observability/README.md
+++ b/ferrotunnel-observability/README.md
@@ -147,7 +147,9 @@ async fn main() {
 use axum::{routing::get, Router};
 use ferrotunnel_observability::gather_metrics;
 
-let app = Router::new().route("/metrics", get(|| async { gather_metrics() }));
+let app = Router::new().route("/metrics", get(|| async {
+    gather_metrics().unwrap_or_else(|_| "failed to gather metrics\n".to_string())
+}));
 ```
 
 ## Configuration

--- a/ferrotunnel-observability/src/dashboard/handlers.rs
+++ b/ferrotunnel-observability/src/dashboard/handlers.rs
@@ -145,13 +145,22 @@ pub async fn get_request_handler(
 ///
 /// GET /api/v1/metrics
 pub async fn metrics_handler() -> Response {
-    let metrics = crate::gather_metrics();
-    (
-        StatusCode::OK,
-        [("content-type", "text/plain; charset=utf-8")],
-        metrics,
-    )
-        .into_response()
+    match crate::gather_metrics() {
+        Ok(metrics) => (
+            StatusCode::OK,
+            [("content-type", "text/plain; charset=utf-8")],
+            metrics,
+        )
+            .into_response(),
+        Err(error) => {
+            tracing::error!(%error, "failed to gather dashboard metrics");
+            error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "METRICS_ERROR",
+                "Failed to gather metrics",
+            )
+        }
+    }
 }
 
 /// Replay a specific request.

--- a/ferrotunnel-observability/src/metrics.rs
+++ b/ferrotunnel-observability/src/metrics.rs
@@ -5,8 +5,10 @@
 //! - **Units**: in the name (e.g. `_seconds`, `_bytes`)
 //! - **Gauges**: descriptive names, no `_total`
 
+use anyhow::Context;
 use prometheus::{register_counter, register_gauge, register_histogram, Counter, Gauge, Histogram};
 use std::sync::LazyLock;
+use std::sync::Once;
 use std::sync::OnceLock;
 use std::time::Duration;
 
@@ -17,6 +19,7 @@ pub static REGISTRY: LazyLock<Registry> = LazyLock::new(Registry::new);
 
 /// Global tunnel metrics. Set when [`init_metrics`] is called.
 static TUNNEL_METRICS: OnceLock<TunnelMetrics> = OnceLock::new();
+static METRICS_INIT: Once = Once::new();
 
 /// Tunnel-level metrics: frames, bytes, decode/encode latency, queue depth.
 ///
@@ -33,43 +36,43 @@ pub struct TunnelMetrics {
 impl TunnelMetrics {
     /// Create and register metrics with the default Prometheus registry.
     pub fn new() -> Self {
+        Self::try_new().expect("register FerroTunnel tunnel metrics")
+    }
+
+    /// Try to create and register metrics with the default Prometheus registry.
+    pub fn try_new() -> Result<Self, prometheus::Error> {
         let frames_processed = register_counter!(
             "ferrotunnel_tunnel_frames_processed_total",
             "Total number of protocol frames processed (decoded or encoded)"
-        )
-        .expect("register ferrotunnel_tunnel_frames_processed_total");
+        )?;
 
         let bytes_transferred = register_counter!(
             "ferrotunnel_tunnel_bytes_transferred_total",
             "Total bytes transferred through the tunnel (data frames only)"
-        )
-        .expect("register ferrotunnel_tunnel_bytes_transferred_total");
+        )?;
 
         let decode_latency = register_histogram!(
             "ferrotunnel_tunnel_decode_latency_seconds",
             "Latency of decoding frames from the wire"
-        )
-        .expect("register ferrotunnel_tunnel_decode_latency_seconds");
+        )?;
 
         let encode_latency = register_histogram!(
             "ferrotunnel_tunnel_encode_latency_seconds",
             "Latency of encoding frames to the wire"
-        )
-        .expect("register ferrotunnel_tunnel_encode_latency_seconds");
+        )?;
 
         let queue_depth = register_gauge!(
             "ferrotunnel_tunnel_queue_depth",
             "Current number of frames queued in the batched sender"
-        )
-        .expect("register ferrotunnel_tunnel_queue_depth");
+        )?;
 
-        Self {
+        Ok(Self {
             frames_processed,
             bytes_transferred,
             decode_latency,
             encode_latency,
             queue_depth,
-        }
+        })
     }
 
     /// Record a decode operation (frames decoded, bytes, and latency).
@@ -116,8 +119,19 @@ pub fn tunnel_metrics() -> Option<&'static TunnelMetrics> {
 /// Initialize the metrics system and register tunnel metrics.
 pub fn init_metrics() {
     let _ = LazyLock::force(&REGISTRY);
-    let _ = TUNNEL_METRICS.set(TunnelMetrics::new());
-    tracing::info!("Metrics infrastructure initialized");
+    if TUNNEL_METRICS.get().is_some() {
+        return;
+    }
+
+    METRICS_INIT.call_once(|| match TunnelMetrics::try_new() {
+        Ok(metrics) => {
+            let _ = TUNNEL_METRICS.set(metrics);
+            tracing::info!("Metrics infrastructure initialized");
+        }
+        Err(error) => {
+            tracing::error!(%error, "failed to initialize metrics infrastructure");
+        }
+    });
 }
 
 /// Returns true if metrics have been initialized.
@@ -127,11 +141,29 @@ pub fn metrics_enabled() -> bool {
 }
 
 /// Gather all metrics into Prometheus text format.
-pub fn gather_metrics() -> String {
+pub fn gather_metrics() -> anyhow::Result<String> {
     use prometheus::Encoder;
     let encoder = prometheus::TextEncoder::new();
     let metric_families = prometheus::gather();
     let mut buffer = Vec::new();
-    encoder.encode(&metric_families, &mut buffer).unwrap();
-    String::from_utf8(buffer).unwrap()
+    encoder
+        .encode(&metric_families, &mut buffer)
+        .context("failed to encode Prometheus metrics")?;
+    String::from_utf8(buffer).context("Prometheus metrics output was not valid UTF-8")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{gather_metrics, init_metrics, metrics_enabled};
+
+    #[test]
+    fn init_metrics_is_idempotent_and_scrape_does_not_panic() {
+        init_metrics();
+        init_metrics();
+
+        assert!(metrics_enabled());
+        let metrics = gather_metrics().expect("metrics scrape should succeed");
+
+        assert!(metrics.contains("ferrotunnel_tunnel_frames_processed_total"));
+    }
 }


### PR DESCRIPTION
## What changed

- Add a fallible `TunnelMetrics::try_new()` path and use it from `init_metrics()`.
- Guard metrics initialization with `Once` before collector construction, so repeated `init_metrics()` / `init_basic_observability()` calls do not eagerly re-register the same Prometheus metric names.
- Change `gather_metrics()` to return `anyhow::Result<String>` instead of unwrapping Prometheus encode and UTF-8 conversion errors.
- Update the CLI metrics endpoint and dashboard metrics handler to return HTTP 500 responses on scrape failure instead of panicking the serving task.
- Add a regression test covering double initialization plus a metrics scrape.
- Update the observability README snippet for the fallible scrape API.

## Why

The previous `OnceLock::set(TunnelMetrics::new())` call evaluated `TunnelMetrics::new()` before `set()`, so a second init attempted to register the same global Prometheus collectors again. That can panic before `OnceLock` has a chance to reject the duplicate value. Separately, `/metrics` scraping used `unwrap()` on encoding and UTF-8 conversion, so an unexpected encoder failure would panic the request task instead of returning an error response.

This keeps `init_metrics()` as a stable `()` API for callers, while making it idempotent and non-panicking in the path described by the issue.

Fixes #137.

## Validation

- `make check`
- `make test`
