### PR TITLE
fix: keep ingress accept loops alive

### DIFF
--- a/ferrotunnel-http/Cargo.toml
+++ b/ferrotunnel-http/Cargo.toml
@@ -21,6 +21,7 @@ hyper = { version = "1", features = ["full", "http2"] }
 http-body-util = "0.1"
 hyper-util = { version = "0.1", features = ["full", "server-auto", "tokio"] }
 bytes = { workspace = true }
+libc = "0.2"
 tracing = "0.1"
 uuid = { workspace = true }
 futures = "0.3"

--- a/ferrotunnel-http/src/accept_errors.rs
+++ b/ferrotunnel-http/src/accept_errors.rs
@@ -1,0 +1,66 @@
+use std::io;
+
+/// File descriptor exhaustion is transient for accept loops: dropping other
+/// connections or raising limits can make the listener usable again.
+#[cfg(unix)]
+use libc::{EMFILE, ENFILE};
+
+pub(crate) fn is_transient_accept_error(error: &io::Error) -> bool {
+    matches!(
+        error.kind(),
+        io::ErrorKind::Interrupted
+            | io::ErrorKind::WouldBlock
+            | io::ErrorKind::ConnectionAborted
+            | io::ErrorKind::ConnectionReset
+    ) || is_fd_exhaustion(error)
+}
+
+#[cfg(unix)]
+fn is_fd_exhaustion(error: &io::Error) -> bool {
+    matches!(error.raw_os_error(), Some(EMFILE | ENFILE))
+}
+
+#[cfg(not(unix))]
+fn is_fd_exhaustion(_error: &io::Error) -> bool {
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_transient_accept_error;
+    use std::io;
+
+    #[test]
+    fn classifies_retryable_accept_errors() {
+        for kind in [
+            io::ErrorKind::Interrupted,
+            io::ErrorKind::WouldBlock,
+            io::ErrorKind::ConnectionAborted,
+            io::ErrorKind::ConnectionReset,
+        ] {
+            assert!(is_transient_accept_error(&io::Error::new(kind, "accept")));
+        }
+    }
+
+    #[test]
+    fn classifies_fatal_accept_errors() {
+        for kind in [
+            io::ErrorKind::AddrNotAvailable,
+            io::ErrorKind::InvalidInput,
+            io::ErrorKind::PermissionDenied,
+        ] {
+            assert!(!is_transient_accept_error(&io::Error::new(kind, "accept")));
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn classifies_file_descriptor_exhaustion_as_retryable() {
+        assert!(is_transient_accept_error(&io::Error::from_raw_os_error(
+            libc::EMFILE
+        )));
+        assert!(is_transient_accept_error(&io::Error::from_raw_os_error(
+            libc::ENFILE
+        )));
+    }
+}

--- a/ferrotunnel-http/src/ingress.rs
+++ b/ferrotunnel-http/src/ingress.rs
@@ -1,3 +1,4 @@
+use crate::accept_errors::is_transient_accept_error;
 use ferrotunnel_common::Result;
 use ferrotunnel_core::tunnel::session::SessionStoreBackend;
 use ferrotunnel_plugin::{PluginAction, PluginRegistry, RequestContext, ResponseContext};
@@ -92,7 +93,18 @@ impl HttpIngress {
         );
 
         loop {
-            let (stream, peer_addr) = listener.accept().await?;
+            let (stream, peer_addr) = match listener.accept().await {
+                Ok(connection) => connection,
+                Err(error) if is_transient_accept_error(&error) => {
+                    warn!(
+                        bind_addr = %self.addr,
+                        error = %error,
+                        "Transient HTTP ingress accept error; continuing"
+                    );
+                    continue;
+                }
+                Err(error) => return Err(error.into()),
+            };
 
             // Acquire connection permit (limit concurrent connections)
             let Ok(permit) = self.connection_semaphore.clone().try_acquire_owned() else {

--- a/ferrotunnel-http/src/lib.rs
+++ b/ferrotunnel-http/src/lib.rs
@@ -1,3 +1,5 @@
+mod accept_errors;
+
 #[cfg(feature = "http3")]
 pub mod http3_ingress;
 pub mod ingress;

--- a/ferrotunnel-http/src/tcp_ingress.rs
+++ b/ferrotunnel-http/src/tcp_ingress.rs
@@ -3,6 +3,7 @@
 //! Provides protocol-agnostic TCP forwarding through the tunnel.
 //! Useful for database connections, SSH, and custom protocols.
 
+use crate::accept_errors::is_transient_accept_error;
 use ferrotunnel_common::Result;
 use ferrotunnel_core::tunnel::session::SessionStoreBackend;
 use ferrotunnel_protocol::frame::Protocol;
@@ -73,7 +74,18 @@ impl TcpIngress {
         info!("TCP Ingress listening on {}", self.addr);
 
         loop {
-            let (stream, peer_addr) = listener.accept().await?;
+            let (stream, peer_addr) = match listener.accept().await {
+                Ok(connection) => connection,
+                Err(error) if is_transient_accept_error(&error) => {
+                    warn!(
+                        bind_addr = %self.addr,
+                        error = %error,
+                        "Transient TCP ingress accept error; continuing"
+                    );
+                    continue;
+                }
+                Err(error) => return Err(error.into()),
+            };
 
             // CRITICAL: Set TCP_NODELAY to disable Nagle's algorithm for low latency
             if let Err(e) = stream.set_nodelay(true) {


### PR DESCRIPTION
Fixes #131.

## What changed
- Added a small accept-error classifier for retryable listener failures.
- HTTP and TCP ingress now log retryable accept errors and continue the listener loop instead of returning immediately.
- Non-retryable accept errors still propagate so genuinely fatal listener failures are not hidden.
- Added unit coverage for retryable, fatal, and Unix file-descriptor exhaustion cases.

## Why
The existing `listener.accept().await?` path meant any accept error permanently stopped the ingress loop. Some accept failures are transient in practice: interrupted syscalls, nonblocking readiness races, per-connection abort/reset cases, and Unix file descriptor exhaustion can clear once the runtime retries or resources free up. Treating those as warnings keeps the ingress available while still preserving fail-fast behavior for errors that indicate a bad bind/listener state.

I used `libc::EMFILE` and `libc::ENFILE` rather than raw errno values so the Unix-specific resource exhaustion cases are explicit and portable across Unix targets.

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p ferrotunnel-http accept_errors`
- `make check`
- `make test`