### PR TITLE
fix: validate builder TLS configs

### DIFF
--- a/ferrotunnel/src/client.rs
+++ b/ferrotunnel/src/client.rs
@@ -25,6 +25,7 @@ use ferrotunnel_core::transport::{tls::TlsTransportConfig, TransportConfig};
 use ferrotunnel_core::TunnelClient;
 use ferrotunnel_http::HttpProxy;
 use ferrotunnel_protocol::frame::Protocol;
+use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tokio::sync::{oneshot, watch};
@@ -51,6 +52,7 @@ pub struct Client {
 pub struct ClientBuilder {
     config: ClientConfig,
     transport_config: Option<TransportConfig>,
+    tls_validation_error: Option<TunnelError>,
 }
 
 impl Client {
@@ -330,8 +332,17 @@ impl ClientBuilder {
     /// When enabled, the client will use TLS to connect to the server.
     #[must_use]
     pub fn tls(mut self, config: &TlsConfig) -> Self {
-        if let Some(tls) = TlsTransportConfig::from_common(config) {
-            self.transport_config = Some(TransportConfig::Tls(tls));
+        match validate_client_tls_config(config) {
+            Ok(()) => {
+                self.tls_validation_error = None;
+                if let Some(tls) = TlsTransportConfig::from_common(config) {
+                    self.transport_config = Some(TransportConfig::Tls(tls));
+                }
+            }
+            Err(error) => {
+                self.tls_validation_error = Some(error);
+                self.transport_config = None;
+            }
         }
         self
     }
@@ -347,6 +358,7 @@ impl ClientBuilder {
         if let Some(quic) =
             ferrotunnel_core::transport::quic::QuicTransportConfig::from_common(config)
         {
+            self.tls_validation_error = None;
             self.transport_config = Some(TransportConfig::Quic(quic));
         }
         self
@@ -361,6 +373,9 @@ impl ClientBuilder {
     /// - `token` must be set
     pub fn build(self) -> Result<Client> {
         self.config.validate()?;
+        if let Some(error) = self.tls_validation_error {
+            return Err(error);
+        }
         Ok(Client {
             config: self.config,
             transport_config: self.transport_config.unwrap_or_default(),
@@ -370,9 +385,44 @@ impl ClientBuilder {
     }
 }
 
+fn validate_client_tls_config(config: &TlsConfig) -> Result<()> {
+    if !config.enabled {
+        return Err(TunnelError::Config(
+            "TLS config is disabled; omit ClientBuilder::tls() or enable TLS".into(),
+        ));
+    }
+
+    if missing_path(config.ca_cert_path.as_ref()) {
+        return Err(TunnelError::Config(
+            "client TLS requires ca_cert_path for server verification".into(),
+        ));
+    }
+
+    let has_cert = !missing_path(config.cert_path.as_ref());
+    let has_key = !missing_path(config.key_path.as_ref());
+    if config.client_auth && (!has_cert || !has_key) {
+        return Err(TunnelError::Config(
+            "client TLS client_auth requires cert_path and key_path".into(),
+        ));
+    }
+
+    if has_cert != has_key {
+        return Err(TunnelError::Config(
+            "client TLS certificate and key paths must be provided together".into(),
+        ));
+    }
+
+    Ok(())
+}
+
+fn missing_path(path: Option<&PathBuf>) -> bool {
+    path.is_none_or(|path| path.as_os_str().is_empty())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::PathBuf;
 
     #[test]
     fn test_client_builder_success() {
@@ -450,14 +500,88 @@ mod tests {
             enabled: false,
             ..Default::default()
         };
+        let result = Client::builder()
+            .server_addr("localhost:7835")
+            .token("secret")
+            .tls(&tls)
+            .build();
+
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("TLS config is disabled"));
+    }
+
+    #[test]
+    fn test_client_builder_tls_missing_ca() {
+        let tls = TlsConfig {
+            enabled: true,
+            ..Default::default()
+        };
+        let result = Client::builder()
+            .server_addr("localhost:7835")
+            .token("secret")
+            .tls(&tls)
+            .build();
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("ca_cert_path"));
+    }
+
+    #[test]
+    fn test_client_builder_tls_rejects_partial_client_auth_material() {
+        let tls = TlsConfig {
+            enabled: true,
+            ca_cert_path: Some(PathBuf::from("ca.pem")),
+            cert_path: Some(PathBuf::from("client.pem")),
+            ..Default::default()
+        };
+        let result = Client::builder()
+            .server_addr("localhost:7835")
+            .token("secret")
+            .tls(&tls)
+            .build();
+
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("provided together"));
+    }
+
+    #[test]
+    fn test_client_builder_tls_rejects_client_auth_without_material() {
+        let tls = TlsConfig {
+            enabled: true,
+            ca_cert_path: Some(PathBuf::from("ca.pem")),
+            client_auth: true,
+            ..Default::default()
+        };
+        let result = Client::builder()
+            .server_addr("localhost:7835")
+            .token("secret")
+            .tls(&tls)
+            .build();
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("client_auth"));
+    }
+
+    #[test]
+    fn test_client_builder_tls_ca_only() {
+        let tls = TlsConfig {
+            enabled: true,
+            ca_cert_path: Some(PathBuf::from("ca.pem")),
+            ..Default::default()
+        };
         let client = Client::builder()
             .server_addr("localhost:7835")
             .token("secret")
             .tls(&tls)
             .build()
-            .expect("should build");
+            .expect("server-auth TLS should not require client certificate material");
 
-        // TLS disabled means no transport config set
         assert!(!client.config().server_addr.is_empty());
     }
 }

--- a/ferrotunnel/src/server.rs
+++ b/ferrotunnel/src/server.rs
@@ -27,7 +27,6 @@ use ferrotunnel_http::HttpIngress;
 use ferrotunnel_http::{Http3Ingress, Http3IngressConfig};
 use ferrotunnel_plugin::PluginRegistry;
 use std::net::SocketAddr;
-#[cfg(feature = "http3")]
 use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::{watch, RwLock};
@@ -50,6 +49,7 @@ pub struct Server {
 pub struct ServerBuilder {
     config: ServerConfig,
     transport_config: Option<TransportConfig>,
+    tls_validation_error: Option<TunnelError>,
 }
 
 impl Server {
@@ -121,8 +121,9 @@ impl Server {
                 .ok()
         });
 
-        let mut ingress =
-            HttpIngress::new(config.http_bind_addr, sessions.clone(), registry.clone());
+        let ingress = HttpIngress::new(config.http_bind_addr, sessions.clone(), registry.clone());
+        #[cfg(feature = "http3")]
+        let mut ingress = ingress;
         #[cfg(feature = "http3")]
         if let Some(value) = alt_svc_header {
             ingress = ingress.with_alt_svc_header(value);
@@ -314,8 +315,17 @@ impl ServerBuilder {
     /// When enabled, the server will use TLS for all connections.
     #[must_use]
     pub fn tls(mut self, config: &TlsConfig) -> Self {
-        if let Some(tls) = TlsTransportConfig::from_common(config) {
-            self.transport_config = Some(TransportConfig::Tls(tls));
+        match validate_server_tls_config(config) {
+            Ok(()) => {
+                self.tls_validation_error = None;
+                if let Some(tls) = TlsTransportConfig::from_common(config) {
+                    self.transport_config = Some(TransportConfig::Tls(tls));
+                }
+            }
+            Err(error) => {
+                self.tls_validation_error = Some(error);
+                self.transport_config = None;
+            }
         }
         self
     }
@@ -330,6 +340,7 @@ impl ServerBuilder {
         if let Some(quic) =
             ferrotunnel_core::transport::quic::QuicTransportConfig::from_common(config)
         {
+            self.tls_validation_error = None;
             self.transport_config = Some(TransportConfig::Quic(quic));
         }
         self
@@ -343,6 +354,9 @@ impl ServerBuilder {
     /// - `token` must be set
     pub fn build(self) -> Result<Server> {
         self.config.validate()?;
+        if let Some(error) = self.tls_validation_error {
+            return Err(error);
+        }
         Ok(Server {
             config: self.config,
             transport_config: self.transport_config.unwrap_or_default(),
@@ -350,6 +364,34 @@ impl ServerBuilder {
             task: None,
         })
     }
+}
+
+fn validate_server_tls_config(config: &TlsConfig) -> Result<()> {
+    if !config.enabled {
+        return Err(TunnelError::Config(
+            "TLS config is disabled; omit ServerBuilder::tls() or enable TLS".into(),
+        ));
+    }
+
+    if missing_path(config.cert_path.as_ref()) {
+        return Err(TunnelError::Config("server TLS requires cert_path".into()));
+    }
+
+    if missing_path(config.key_path.as_ref()) {
+        return Err(TunnelError::Config("server TLS requires key_path".into()));
+    }
+
+    if config.client_auth && missing_path(config.ca_cert_path.as_ref()) {
+        return Err(TunnelError::Config(
+            "server TLS client_auth requires ca_cert_path".into(),
+        ));
+    }
+
+    Ok(())
+}
+
+fn missing_path(path: Option<&PathBuf>) -> bool {
+    path.is_none_or(|path| path.as_os_str().is_empty())
 }
 
 #[cfg(test)]
@@ -425,13 +467,70 @@ mod tests {
             enabled: false,
             ..Default::default()
         };
+        let result = Server::builder().token("secret").tls(&tls).build();
+
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("TLS config is disabled"));
+    }
+
+    #[test]
+    fn test_server_builder_tls_missing_cert() {
+        let tls = TlsConfig {
+            enabled: true,
+            key_path: Some(PathBuf::from("server.key")),
+            ..Default::default()
+        };
+        let result = Server::builder().token("secret").tls(&tls).build();
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("cert_path"));
+    }
+
+    #[test]
+    fn test_server_builder_tls_missing_key() {
+        let tls = TlsConfig {
+            enabled: true,
+            cert_path: Some(PathBuf::from("server.crt")),
+            ..Default::default()
+        };
+        let result = Server::builder().token("secret").tls(&tls).build();
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("key_path"));
+    }
+
+    #[test]
+    fn test_server_builder_tls_client_auth_missing_ca() {
+        let tls = TlsConfig {
+            enabled: true,
+            cert_path: Some(PathBuf::from("server.crt")),
+            key_path: Some(PathBuf::from("server.key")),
+            client_auth: true,
+            ..Default::default()
+        };
+        let result = Server::builder().token("secret").tls(&tls).build();
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("ca_cert_path"));
+    }
+
+    #[test]
+    fn test_server_builder_tls_with_cert_and_key() {
+        let tls = TlsConfig {
+            enabled: true,
+            cert_path: Some(PathBuf::from("server.crt")),
+            key_path: Some(PathBuf::from("server.key")),
+            ..Default::default()
+        };
         let server = Server::builder()
             .token("secret")
             .tls(&tls)
             .build()
-            .expect("should build");
+            .expect("server-auth TLS should accept certificate and key paths");
 
-        // Server should work with TLS disabled
         assert!(!server.config().token.is_empty());
     }
 }


### PR DESCRIPTION
Fixes #141.

## What changed
- `ClientBuilder::tls` now stores invalid TLS config errors and returns them from `build()` instead of silently leaving the transport unchanged.
- `ServerBuilder::tls` now rejects disabled configs and missing server certificate/key paths during `build()`; client-auth server TLS also requires a CA path.
- Client TLS now rejects missing CA paths and incomplete or misdeclared client-auth material, while still allowing CA-only server-auth TLS because client certificates are optional unless client auth is requested.
- Added builder regression tests for disabled TLS and incomplete TLS path combinations.

## Why
Calling `.tls(&cfg)` is an explicit opt-in to TLS. If `cfg.enabled == false`, keeping the default TCP transport is indistinguishable from never calling `.tls()` and makes a configuration mistake look successful. Server TLS with missing cert/key paths has the same shape: it builds a transport with empty paths and only fails later when the acceptor is created. Returning these as build-time config errors gives callers deterministic feedback before any connection or background task starts.

## Validation
- `cargo test -p ferrotunnel test_client_builder_tls`
- `cargo test -p ferrotunnel test_server_builder_tls`
- `make check`
- `make test`