### PR TITLE
fix: install rustls provider for library TLS

### DIFF
--- a/ferrotunnel-core/src/transport/tls.rs
+++ b/ferrotunnel-core/src/transport/tls.rs
@@ -7,9 +7,17 @@ use rustls::{ClientConfig, RootCertStore, ServerConfig};
 use rustls_pki_types::pem::PemObject;
 use std::io::{self, ErrorKind};
 use std::path::Path;
-use std::sync::Arc;
+use std::sync::{Arc, Once};
 use tokio::net::TcpStream;
 use tokio_rustls::{TlsAcceptor, TlsConnector};
+
+fn install_default_crypto_provider() {
+    static INSTALL: Once = Once::new();
+    INSTALL.call_once(|| {
+        // Err means another process-wide provider is already installed, which is acceptable.
+        let _ = rustls::crypto::ring::default_provider().install_default();
+    });
+}
 
 #[derive(Debug, Clone, Default)]
 pub struct TlsTransportConfig {
@@ -113,6 +121,8 @@ impl rustls::client::danger::ServerCertVerifier for InsecureServerCertVerifier {
 }
 
 pub fn create_client_config(config: &TlsTransportConfig) -> io::Result<Arc<ClientConfig>> {
+    install_default_crypto_provider();
+
     let builder = ClientConfig::builder();
 
     let builder = if config.skip_verify {
@@ -151,6 +161,8 @@ pub fn create_client_config(config: &TlsTransportConfig) -> io::Result<Arc<Clien
 }
 
 pub fn create_server_config(config: &TlsTransportConfig) -> io::Result<Arc<ServerConfig>> {
+    install_default_crypto_provider();
+
     let certs = load_certs(Path::new(&config.cert_path))?;
     let key = load_private_key(Path::new(&config.key_path))?;
 

--- a/tests/integration/tls_test.rs
+++ b/tests/integration/tls_test.rs
@@ -9,9 +9,6 @@ use std::time::Duration;
 /// Test client connecting to server over TLS
 #[tokio::test]
 async fn test_tls_connection() {
-    let _ = rustls::crypto::ring::default_provider()
-        .install_default()
-        .ok();
     let config = TestConfig::default();
 
     // Create temp directory for certs


### PR DESCRIPTION
Fixes #121.

## What changed
- Installed the `ring` rustls crypto provider from the core TLS client/server config constructors.
- Guarded installation with `Once`, matching the process-wide provider requirement in rustls 0.23.
- Left the already-installed case as acceptable: `install_default()` returns `Err` when another provider is already installed, and that means the process already has a provider available.
- Removed the manual provider install from the public TLS integration test so `ferrotunnel::Server`/`ferrotunnel::Client` exercise the library setup path directly.

## Why
The CLI already installs the provider at process startup, but embedders using the library API do not necessarily run through the CLI. Creating TLS client/server configs inside `ferrotunnel-core` is the common point for plain TLS and QUIC config construction, so installing there makes embedded TLS deterministic without requiring callers to know rustls provider internals.

## Validation
- `cargo test -p ferrotunnel-tests test_tls_connection --all-features`
- `make check`
- `make test`
- `make check` after the final comment-only edit