### PR TITLE
fix: warn on disabled certificate verification (#150)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-06-11
+
+### Security
+
+- Fixed token authentication timing side-channel by replacing `HashSet<String>::contains` with constant-time token comparison in `TokenAuthPlugin` ([#124](https://github.com/ferro-labs/ferrotunnel/issues/124)).
+- Hardened the observability dashboard: it now binds to loopback by default, requires explicit opt-in plus authentication for non-loopback binds, removes wildcard CORS, and enforces dashboard API authentication with constant-time token comparison ([#125](https://github.com/ferro-labs/ferrotunnel/issues/125)).
+- Fixed stored XSS risks in the dashboard by rendering captured request paths, headers, tunnel metadata, and public URLs through safe text/escaping paths, and by only using `http` or `https` public URLs as links ([#126](https://github.com/ferro-labs/ferrotunnel/issues/126)).
+- Added client and server handshake read timeouts for TCP, TLS, and QUIC paths so silent peers cannot hold session permits indefinitely ([#127](https://github.com/ferro-labs/ferrotunnel/issues/127)).
+- Stopped requiring server tokens on the command line; the server now supports `FERROTUNNEL_TOKEN`, `--token-file`, or secure prompt fallback, and hides token environment values in help output ([#128](https://github.com/ferro-labs/ferrotunnel/issues/128)).
+- Made `ferrotunnel client --tls` secure by default: verified TLS now requires `--tls-ca` unless `--tls-skip-verify` is explicitly set ([#116](https://github.com/ferro-labs/ferrotunnel/issues/116)).
+- Added warnings and symmetric config handling for TLS/QUIC paths that disable certificate verification ([#143](https://github.com/ferro-labs/ferrotunnel/issues/143)).
+
+### Added
+
+- Added dashboard CLI controls for `--dashboard-bind`, `--dashboard-allow-non-loopback`, and `--dashboard-auth-token`, with a generated dashboard token URL when no token is supplied.
+- Added regression coverage for dashboard bind validation, dashboard API authentication, token-file loading, constant-time plugin auth, TLS argument validation, and handshake timeout behavior.
+
+### Changed
+
+- Updated CLI, deployment, observability, and release-planning docs for the safer token, dashboard, and TLS defaults.
+
 ## [1.0.8] - 2026-04-26
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.0.8"
+version = "1.1.0"
 edition = "2021"
 rust-version = "1.91"
 authors = ["Mitul Shah <hello@ferrolabs.ai>"]
@@ -53,7 +53,7 @@ tokio = { version = "1", features = ["full"] }
 
 # Logging
 tracing = "0.1"
-ferrotunnel-observability = { version = "1.0.8", path = "ferrotunnel-observability" }
+ferrotunnel-observability = { version = "1.1.0", path = "ferrotunnel-observability" }
 
 # QUIC transport
 quinn = { version = "0.11", default-features = false, features = ["runtime-tokio", "rustls-ring"] }

--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ ferrotunnel server [OPTIONS]
 
 | Option | Env Variable | Default | Description |
 |--------|--------------|---------|-------------|
-| `--token` | `FERROTUNNEL_TOKEN` | optional | Auth token; avoid because argv can expose it |
+| _(env only)_ | `FERROTUNNEL_TOKEN` | optional | Auth token; not a CLI flag so it can't leak via argv |
 | `--token-file` | `FERROTUNNEL_TOKEN_FILE` | - | Read auth token from a file |
 | `--bind` | `FERROTUNNEL_BIND` | `0.0.0.0:7835` | Control plane |
 | `--http-bind` | `FERROTUNNEL_HTTP_BIND` | `0.0.0.0:8080` | HTTP ingress |

--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ cargo install ferrotunnel-cli
 
 ```bash
 
-# Start server
-ferrotunnel server --token secret
+# Start server; enter the token at the prompt or set FERROTUNNEL_TOKEN
+ferrotunnel server
 
-# Start client (in another terminal; token from env or secure prompt if omitted)
+# Start client in another terminal; use the same token via env or prompt
 ferrotunnel client --server localhost:7835 --local-addr 127.0.0.1:8080 --tunnel-id my-app
 ```
 
@@ -150,11 +150,14 @@ FerroTunnel v1.0.7+ supports QUIC as an alternative transport for the tunnel con
 cargo build --features quic
 
 # Server: keep the TCP control plane on :7835 and add a shared-state QUIC listener on :7836
-ferrotunnel server --token secret --quic-bind 0.0.0.0:7836 --tls-cert server.crt --tls-key server.key
+# Token is read from FERROTUNNEL_TOKEN, --token-file, or the secure prompt.
+ferrotunnel server --quic-bind 0.0.0.0:7836 --tls-cert server.crt --tls-key server.key
 
 # Client: connect via QUIC
 ferrotunnel client --server 127.0.0.1:7836 --quic --tls-skip-verify
 ```
+
+`--tls-skip-verify` is explicit insecure mode for local or self-signed testing only.
 
 **Library**:
 
@@ -206,7 +209,8 @@ HTTP/3 ingress is separate from QUIC tunnel transport: it uses `h3` +
 cargo build -p ferrotunnel-cli --features http3
 
 # Server: HTTP/1.1+HTTP/2 on TCP :8080, HTTP/3 on UDP :8443
-ferrotunnel server --token secret \
+# Token is read from FERROTUNNEL_TOKEN, --token-file, or the secure prompt.
+ferrotunnel server \
   --http-bind 0.0.0.0:8080 \
   --http3-bind 0.0.0.0:8443 \
   --tls-cert server.crt \
@@ -309,7 +313,8 @@ ferrotunnel server [OPTIONS]
 
 | Option | Env Variable | Default | Description |
 |--------|--------------|---------|-------------|
-| `--token` | `FERROTUNNEL_TOKEN` | required | Auth token |
+| `--token` | `FERROTUNNEL_TOKEN` | optional | Auth token; avoid because argv can expose it |
+| `--token-file` | `FERROTUNNEL_TOKEN_FILE` | - | Read auth token from a file |
 | `--bind` | `FERROTUNNEL_BIND` | `0.0.0.0:7835` | Control plane |
 | `--http-bind` | `FERROTUNNEL_HTTP_BIND` | `0.0.0.0:8080` | HTTP ingress |
 | `--tcp-bind` | `FERROTUNNEL_TCP_BIND` | - | TCP ingress |
@@ -331,10 +336,15 @@ ferrotunnel client [OPTIONS]
 | `--local-addr` | `FERROTUNNEL_LOCAL_ADDR` | `127.0.0.1:8000` | Local service |
 | `--tunnel-id` | `FERROTUNNEL_TUNNEL_ID` | (auto) | Tunnel ID for HTTP routing |
 | `--dashboard-port` | `FERROTUNNEL_DASHBOARD_PORT` | `4040` | Dashboard port |
-| `--tls` | `FERROTUNNEL_TLS` | false | Enable TLS |
-| `--tls-ca` | `FERROTUNNEL_TLS_CA` | - | CA certificate |
+| `--dashboard-bind` | `FERROTUNNEL_DASHBOARD_BIND` | `127.0.0.1` | Dashboard bind address |
+| `--dashboard-allow-non-loopback` | `FERROTUNNEL_DASHBOARD_ALLOW_NON_LOOPBACK` | `false` | Allow exposed dashboard bind; requires auth token |
+| `--dashboard-auth-token` | `FERROTUNNEL_DASHBOARD_AUTH_TOKEN` | generated | Dashboard API auth token |
+| `--tls` | `FERROTUNNEL_TLS` | false | Enable TLS; requires `--tls-ca` unless `--tls-skip-verify` is explicit |
+| `--tls-ca` | `FERROTUNNEL_TLS_CA` | - | CA certificate for verified TLS |
 | `--quic`* | `FERROTUNNEL_QUIC` | false | Use QUIC transport |
 | `--quic-0rtt`* | `FERROTUNNEL_QUIC_0RTT` | false | Enable 0-RTT reconnection |
+
+For TCP/TLS clients, `--tls` requires `--tls-ca` unless `--tls-skip-verify` is explicitly set.
 
 *\* Requires `--features quic` at build time.*
 *\*\* Requires `--features http3` at build time.*
@@ -383,8 +393,9 @@ You can pull the official image from GitHub Container Registry:
 # Pull the latest image
 docker pull ghcr.io/ferro-labs/ferrotunnel:latest
 
-# Run as a server
-docker run -p 7835:7835 -p 8080:8080 ghcr.io/ferro-labs/ferrotunnel:latest server --token secret
+# Run as a server using FERROTUNNEL_TOKEN from the host environment
+export FERROTUNNEL_TOKEN=secret
+docker run -e FERROTUNNEL_TOKEN -p 7835:7835 -p 8080:8080 ghcr.io/ferro-labs/ferrotunnel:latest server
 ```
 
 #### Using Docker Compose

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -5,12 +5,16 @@
 ### Server
 
 ```bash
+# The server reads its token from FERROTUNNEL_TOKEN (or --token-file, or a
+# secure TTY prompt). It is never accepted as a CLI flag, so it cannot leak
+# via the process list.
+export FERROTUNNEL_TOKEN="your-secret-token"
+
 # Basic server (no TLS)
-ferrotunnel server --bind 0.0.0.0:8080 --token "your-secret-token"
+ferrotunnel server --bind 0.0.0.0:8080
 
 # With TLS
 ferrotunnel server --bind 0.0.0.0:8443 \
-  --token "your-secret-token" \
   --tls-cert /path/to/server.crt \
   --tls-key /path/to/server.key
 ```
@@ -105,13 +109,13 @@ ingress. When enabled, the TCP ingress advertises the HTTP/3 endpoint with an
 ```bash
 cargo build -p ferrotunnel-cli --features http3
 
+export FERROTUNNEL_TOKEN="your-secret-token"
 ferrotunnel server \
   --bind 0.0.0.0:7835 \
   --http-bind 0.0.0.0:8080 \
   --http3-bind 0.0.0.0:8443 \
   --tls-cert /etc/ferrotunnel/server.crt \
-  --tls-key /etc/ferrotunnel/server.key \
-  --token "your-secret-token"
+  --tls-key /etc/ferrotunnel/server.key
 ```
 
 Allow UDP traffic to the HTTP/3 bind port in firewalls and load balancers. The
@@ -222,7 +226,6 @@ services:
     command: >
       server
       --bind 0.0.0.0:7835
-      --token ${FERROTUNNEL_TOKEN}
       --tls-cert /etc/ferrotunnel/server.crt
       --tls-key /etc/ferrotunnel/server.key
     restart: unless-stopped

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -132,9 +132,9 @@ export RUST_LOG="info"                            # Log level
 
 # TLS (optional)
 export FERROTUNNEL_TLS="true"                     # Enable TLS
-export FERROTUNNEL_TLS_CA="/path/to/ca.crt"      # CA certificate
+export FERROTUNNEL_TLS_CA="/path/to/ca.crt"      # Required for verified TLS
 export FERROTUNNEL_TLS_SERVER_NAME="tunnel.example.com"  # SNI hostname
-export FERROTUNNEL_TLS_SKIP_VERIFY="false"       # Skip cert verification
+export FERROTUNNEL_TLS_SKIP_VERIFY="false"       # Explicit insecure mode only
 
 # Mutual TLS (optional)
 export FERROTUNNEL_TLS_CERT="/path/to/client.crt"

--- a/docs/release-1.1.0-plan.md
+++ b/docs/release-1.1.0-plan.md
@@ -1,0 +1,35 @@
+# Release 1.1.0 Fix Plan
+
+Branch: `feature/1.1.0`
+Milestone: `v1.1.0`
+Snapshot date: 2026-06-09
+
+## Milestone Scope
+
+The `v1.1.0` milestone shows 7 open issues and 0 closed issues in GitHub, but
+all 7 fixes are now implemented on `feature/1.1.0`. GitHub will keep the issues
+open until the release branch reaches the default branch or the issue-closing PR
+is merged.
+
+| Issue | Severity | Area | Branch status | Fix summary |
+| --- | --- | --- | --- | --- |
+| [#143](https://github.com/ferro-labs/ferrotunnel/issues/143) | Medium | TLS/QUIC transport | Covered by merged PR [#150](https://github.com/ferro-labs/ferrotunnel/pull/150) at `b706551` | Warn on TLS/QUIC skip-verify and make TLS/QUIC config symmetric. |
+| [#124](https://github.com/ferro-labs/ferrotunnel/issues/124) | Critical | Plugin auth | Implemented | Token auth now scans tokens with constant-time byte comparison and focused tests. |
+| [#125](https://github.com/ferro-labs/ferrotunnel/issues/125) | Critical | Observability dashboard | Implemented | Dashboard binds loopback by default, non-loopback needs explicit opt-in plus auth, API routes enforce bearer/header/cookie/query token auth, and wildcard CORS is removed. |
+| [#126](https://github.com/ferro-labs/ferrotunnel/issues/126) | Critical | Dashboard UI | Implemented | Dashboard renders captured traffic through text/escaping paths and only uses safe `http` or `https` public URLs as links. |
+| [#127](https://github.com/ferro-labs/ferrotunnel/issues/127) | Critical | Core tunnel handshake | Implemented | Client/server TCP, TLS, and QUIC handshake reads now use a default 10s timeout with regression coverage. |
+| [#128](https://github.com/ferro-labs/ferrotunnel/issues/128) | Critical | CLI server secrets | Implemented | Server token is optional on argv, supports env/token-file/prompt, hides env values, and docs avoid argv secrets. |
+| [#116](https://github.com/ferro-labs/ferrotunnel/issues/116) | High | CLI TLS | Implemented | `ferrotunnel client --tls` now requires `--tls-ca` unless `--tls-skip-verify` is explicitly set, with CLI tests and docs. |
+
+## Validation Gates
+
+Completed locally on this branch:
+
+```bash
+node --check ferrotunnel-observability/src/dashboard/static/app.js
+make check
+cargo test --workspace --all-features
+make audit
+```
+
+`make audit` completed successfully. It reported allowed `rand` advisories and existing duplicate/license warnings through `cargo deny`, and the command exited 0.

--- a/ferrotunnel-cli/Cargo.toml
+++ b/ferrotunnel-cli/Cargo.toml
@@ -17,12 +17,12 @@ doc = false
 
 [dependencies]
 # Core functionality
-ferrotunnel-core = { version = "1.0.8", path = "../ferrotunnel-core", features = [
+ferrotunnel-core = { version = "1.1.0", path = "../ferrotunnel-core", features = [
     "metrics",
 ] }
-ferrotunnel-http = { version = "1.0.8", path = "../ferrotunnel-http" }
-ferrotunnel-protocol = { version = "1.0.8", path = "../ferrotunnel-protocol" }
-ferrotunnel-plugin = { version = "1.0.8", path = "../ferrotunnel-plugin" }
+ferrotunnel-http = { version = "1.1.0", path = "../ferrotunnel-http" }
+ferrotunnel-protocol = { version = "1.1.0", path = "../ferrotunnel-protocol" }
+ferrotunnel-plugin = { version = "1.1.0", path = "../ferrotunnel-plugin" }
 ferrotunnel-observability = { workspace = true, features = [
     "dashboard",
     "axum",

--- a/ferrotunnel-cli/README.md
+++ b/ferrotunnel-cli/README.md
@@ -20,10 +20,17 @@ ferrotunnel <COMMAND> [OPTIONS]
 
 ### Server
 
-Run the tunnel server:
+Run the tunnel server. Prefer the environment, a token file, or the secure prompt so the token is not exposed in process arguments.
 
 ```bash
-ferrotunnel server --token my-secret-token
+export FERROTUNNEL_TOKEN=my-secret-token
+ferrotunnel server
+
+# Or read the token from a secret file
+ferrotunnel server --token-file /run/secrets/ferrotunnel-token
+
+# Or omit both to enter the token securely at the prompt
+ferrotunnel server
 ```
 
 **Options:**
@@ -33,7 +40,8 @@ ferrotunnel server --token my-secret-token
 | `--bind` | `FERROTUNNEL_BIND` | `0.0.0.0:7835` | Tunnel control plane address |
 | `--http-bind` | `FERROTUNNEL_HTTP_BIND` | `0.0.0.0:8080` | HTTP ingress address |
 | `--tcp-bind` | `FERROTUNNEL_TCP_BIND` | - | TCP ingress address (optional) |
-| `--token` | `FERROTUNNEL_TOKEN` | (required) | Authentication token |
+| `--token` | `FERROTUNNEL_TOKEN` | (optional) | Authentication token; avoid for shared systems because argv can expose it |
+| `--token-file` | `FERROTUNNEL_TOKEN_FILE` | - | Read authentication token from a file |
 | `--log-level` | `RUST_LOG` | `info` | Log level |
 | `--metrics-bind` | `FERROTUNNEL_METRICS_BIND` | `0.0.0.0:9090` | Prometheus metrics address |
 | `--observability` | `FERROTUNNEL_OBSERVABILITY` | `false` | Enable tracing |
@@ -57,9 +65,6 @@ ferrotunnel server --token my-secret-token
 Run the tunnel client:
 
 ```bash
-# With token on command line
-ferrotunnel client --server tunnel.example.com:7835 --token my-secret-token
-
 # Token from environment (recommended for scripts)
 export FERROTUNNEL_TOKEN=my-secret-token
 ferrotunnel client --server tunnel.example.com:7835
@@ -78,13 +83,16 @@ ferrotunnel client --server tunnel.example.com:7835
 | `--local-addr` | `FERROTUNNEL_LOCAL_ADDR` | `127.0.0.1:8000` | Local service to forward |
 | `--tunnel-id` | `FERROTUNNEL_TUNNEL_ID` | (auto) | Tunnel ID for HTTP routing (matched against Host header) |
 | `--dashboard-port` | `FERROTUNNEL_DASHBOARD_PORT` | `4040` | Dashboard port |
+| `--dashboard-bind` | `FERROTUNNEL_DASHBOARD_BIND` | `127.0.0.1` | Dashboard bind address |
+| `--dashboard-allow-non-loopback` | `FERROTUNNEL_DASHBOARD_ALLOW_NON_LOOPBACK` | `false` | Allow exposed dashboard bind; requires auth token |
+| `--dashboard-auth-token` | `FERROTUNNEL_DASHBOARD_AUTH_TOKEN` | generated | Dashboard API auth token |
 | `--no-dashboard` | - | `false` | Disable dashboard |
 | `--log-level` | `RUST_LOG` | `info` | Log level |
 | `--observability` | `FERROTUNNEL_OBSERVABILITY` | `false` | Enable tracing |
 | `--metrics` | `FERROTUNNEL_METRICS` | `false` | Enable metrics collection |
-| `--tls` | `FERROTUNNEL_TLS` | `false` | Enable TLS |
-| `--tls-skip-verify` | `FERROTUNNEL_TLS_SKIP_VERIFY` | `false` | Skip certificate verification |
-| `--tls-ca` | `FERROTUNNEL_TLS_CA` | - | CA certificate path |
+| `--tls` | `FERROTUNNEL_TLS` | `false` | Enable TLS; requires `--tls-ca` unless `--tls-skip-verify` is explicit |
+| `--tls-skip-verify` | `FERROTUNNEL_TLS_SKIP_VERIFY` | `false` | Explicit insecure mode; skip certificate verification |
+| `--tls-ca` | `FERROTUNNEL_TLS_CA` | - | CA certificate path for verified TLS |
 | `--tls-server-name` | `FERROTUNNEL_TLS_SERVER_NAME` | - | SNI hostname |
 | `--tls-cert` | `FERROTUNNEL_TLS_CERT` | - | Client certificate (mTLS) |
 | `--tls-key` | `FERROTUNNEL_TLS_KEY` | - | Client private key (mTLS) |
@@ -106,10 +114,12 @@ ferrotunnel version
 ### Quick Start
 
 ```bash
-# Terminal 1: Start server
-ferrotunnel server --token secret
+# Terminal 1: Start server (token from env or prompt if omitted)
+export FERROTUNNEL_TOKEN=secret
+ferrotunnel server
 
-# Terminal 2: Start client (token from env or prompt if omitted)
+# Terminal 2: Start client (use the same token via env or prompt)
+export FERROTUNNEL_TOKEN=secret
 ferrotunnel client --server localhost:7835 --local-addr 127.0.0.1:8080
 
 # Terminal 3: Start local service
@@ -119,14 +129,16 @@ python3 -m http.server 8080
 ### With TLS
 
 ```bash
-# Server with TLS
-ferrotunnel server --token secret \
+# Server with TLS (token from env or prompt if omitted)
+ferrotunnel server \
   --tls-cert server.crt --tls-key server.key
 
-# Client with TLS
-ferrotunnel client --server tunnel.example.com:7835 --token secret \
+# Client with TLS (token from env or prompt if omitted)
+ferrotunnel client --server tunnel.example.com:7835 \
   --tls --tls-ca ca.crt
 ```
+
+`--tls` requires `--tls-ca` for certificate verification. Use `--tls-skip-verify` only when explicitly accepting insecure self-signed testing mode.
 
 ### With QUIC Transport
 
@@ -134,13 +146,13 @@ ferrotunnel client --server tunnel.example.com:7835 --token secret \
 # Build with QUIC support
 cargo install ferrotunnel-cli --features quic
 
-# Server with QUIC endpoint
-ferrotunnel server --token secret \
+# Server with QUIC endpoint (token from env or prompt if omitted)
+ferrotunnel server \
   --tls-cert server.crt --tls-key server.key \
   --quic-bind 0.0.0.0:7836
 
-# Client connecting via QUIC
-ferrotunnel client --server 127.0.0.1:7836 --token secret \
+# Client connecting via QUIC (token from env or prompt if omitted)
+ferrotunnel client --server 127.0.0.1:7836 \
   --quic --tls-skip-verify
 ```
 
@@ -151,7 +163,8 @@ ferrotunnel client --server 127.0.0.1:7836 --token secret \
 cargo install ferrotunnel-cli --features http3
 
 # HTTP/1.1 + HTTP/2 ingress on TCP :8080; HTTP/3 ingress on UDP :8443
-ferrotunnel server --token secret \
+# Token is read from FERROTUNNEL_TOKEN, --token-file, or the secure prompt.
+ferrotunnel server \
   --http-bind 0.0.0.0:8080 \
   --http3-bind 0.0.0.0:8443 \
   --tls-cert server.crt \
@@ -164,16 +177,23 @@ strict `Host`-based tunnel routing as the regular HTTP ingress.
 
 ### Using Environment Variables
 
-Avoid putting the token on the command line (visible in process list and shell history). Use the environment or a secure prompt instead:
+Avoid putting the token on the command line: `--token` can be visible in process listings and shell history. Use the environment, a server token file, or the secure prompt instead:
 
 ```bash
 export FERROTUNNEL_TOKEN=my-secret-token
-export FERROTUNNEL_SERVER=tunnel.example.com:7835
 
+# Server reads FERROTUNNEL_TOKEN or prompts when omitted
+ferrotunnel server
+
+# Server can also read from a file managed by your secret store
+ferrotunnel server --token-file /run/secrets/ferrotunnel-token
+
+# Client reads FERROTUNNEL_TOKEN or prompts when omitted
+export FERROTUNNEL_SERVER=tunnel.example.com:7835
 ferrotunnel client --local-addr 127.0.0.1:3000
 ```
 
-If `--token` and `FERROTUNNEL_TOKEN` are both unset, the client prompts for the token on the TTY (input is not echoed).
+For the server, if `--token`, `FERROTUNNEL_TOKEN`, and `--token-file` are unset, the CLI prompts for the token on the TTY (input is not echoed). The client prompts when `--token` and `FERROTUNNEL_TOKEN` are unset.
 
 ## Developer Tools
 

--- a/ferrotunnel-cli/README.md
+++ b/ferrotunnel-cli/README.md
@@ -40,7 +40,7 @@ ferrotunnel server
 | `--bind` | `FERROTUNNEL_BIND` | `0.0.0.0:7835` | Tunnel control plane address |
 | `--http-bind` | `FERROTUNNEL_HTTP_BIND` | `0.0.0.0:8080` | HTTP ingress address |
 | `--tcp-bind` | `FERROTUNNEL_TCP_BIND` | - | TCP ingress address (optional) |
-| `--token` | `FERROTUNNEL_TOKEN` | (optional) | Authentication token; avoid for shared systems because argv can expose it |
+| _(env only)_ | `FERROTUNNEL_TOKEN` | (optional) | Authentication token; not accepted as a CLI flag so it cannot leak via the process list |
 | `--token-file` | `FERROTUNNEL_TOKEN_FILE` | - | Read authentication token from a file |
 | `--log-level` | `RUST_LOG` | `info` | Log level |
 | `--metrics-bind` | `FERROTUNNEL_METRICS_BIND` | `0.0.0.0:9090` | Prometheus metrics address |
@@ -177,7 +177,7 @@ strict `Host`-based tunnel routing as the regular HTTP ingress.
 
 ### Using Environment Variables
 
-Avoid putting the token on the command line: `--token` can be visible in process listings and shell history. Use the environment, a server token file, or the secure prompt instead:
+Never put the token on the command line — argv is visible in process listings (`ps`) and shell history. The **server does not accept a `--token` flag**; supply its token via the environment, a token file, or the secure prompt. (The client still accepts `--token` for convenience, but the environment or prompt is preferred there too.)
 
 ```bash
 export FERROTUNNEL_TOKEN=my-secret-token
@@ -193,7 +193,7 @@ export FERROTUNNEL_SERVER=tunnel.example.com:7835
 ferrotunnel client --local-addr 127.0.0.1:3000
 ```
 
-For the server, if `--token`, `FERROTUNNEL_TOKEN`, and `--token-file` are unset, the CLI prompts for the token on the TTY (input is not echoed). The client prompts when `--token` and `FERROTUNNEL_TOKEN` are unset.
+For the server, if `FERROTUNNEL_TOKEN` and `--token-file` are unset, the CLI prompts for the token on the TTY (input is not echoed). The client prompts when `--token` and `FERROTUNNEL_TOKEN` are unset.
 
 ## Developer Tools
 

--- a/ferrotunnel-cli/src/commands/client.rs
+++ b/ferrotunnel-cli/src/commands/client.rs
@@ -71,6 +71,29 @@ pub struct DashboardConfig {
     )]
     pub port: u16,
 
+    /// Dashboard bind address. Defaults to loopback; non-loopback requires --dashboard-allow-non-loopback.
+    #[arg(
+        long = "dashboard-bind",
+        default_value = "127.0.0.1",
+        env = "FERROTUNNEL_DASHBOARD_BIND"
+    )]
+    pub bind: std::net::IpAddr,
+
+    /// Allow dashboard to bind to a non-loopback address.
+    #[arg(
+        long = "dashboard-allow-non-loopback",
+        env = "FERROTUNNEL_DASHBOARD_ALLOW_NON_LOOPBACK"
+    )]
+    pub allow_non_loopback: bool,
+
+    /// Token required for dashboard API requests.
+    #[arg(
+        long = "dashboard-auth-token",
+        env = "FERROTUNNEL_DASHBOARD_AUTH_TOKEN",
+        hide_env_values = true
+    )]
+    pub auth_token: Option<String>,
+
     /// Disable dashboard
     #[arg(long = "no-dashboard")]
     pub disabled: bool,
@@ -79,11 +102,11 @@ pub struct DashboardConfig {
 /// TLS configuration for secure server connections (flattened into ClientFeatureArgs)
 #[derive(Args, Debug)]
 pub struct TlsConfig {
-    /// Enable TLS for server connection
+    /// Enable TLS for server connection. Requires --tls-ca unless --tls-skip-verify is set.
     #[arg(long = "tls", env = "FERROTUNNEL_TLS")]
     pub enabled: bool,
 
-    /// Skip TLS certificate verification (insecure, for self-signed certs)
+    /// Skip TLS certificate verification. This is insecure and must be explicit.
     #[arg(long = "tls-skip-verify", env = "FERROTUNNEL_TLS_SKIP_VERIFY")]
     pub skip_verify: bool,
 }
@@ -125,7 +148,7 @@ pub struct ClientArgs {
     #[command(flatten)]
     pub features: ClientFeatureArgs,
 
-    /// Path to CA certificate for TLS verification
+    /// Path to CA certificate for TLS verification. Required with --tls unless --tls-skip-verify is set.
     #[arg(long, env = "FERROTUNNEL_TLS_CA")]
     tls_ca: Option<std::path::PathBuf>,
 
@@ -183,6 +206,7 @@ pub async fn run(args: ClientArgs) -> Result<()> {
     info!("Starting FerroTunnel Client v{}", env!("CARGO_PKG_VERSION"));
 
     let token = resolve_token(&args)?;
+    validate_tls_args(&args)?;
 
     // Determine tunnel ID for routing
     let tunnel_id_string: Option<String> = args.tunnel_id.clone().or_else(|| {
@@ -199,7 +223,7 @@ pub async fn run(args: ClientArgs) -> Result<()> {
 
     // Start Dashboard and configure proxy
     let proxy: Arc<dyn StreamHandler> = if let Some(tunnel_id) = dashboard_tunnel_id {
-        setup_dashboard(&args, tunnel_id).await
+        setup_dashboard(&args, tunnel_id).await?
     } else {
         Arc::new(ferrotunnel_http::HttpProxy::new(args.local_addr.clone()))
     };
@@ -318,17 +342,39 @@ pub async fn run(args: ClientArgs) -> Result<()> {
     Ok(())
 }
 
-async fn setup_dashboard(args: &ClientArgs, tunnel_id: uuid::Uuid) -> Arc<dyn StreamHandler> {
+async fn setup_dashboard(
+    args: &ClientArgs,
+    tunnel_id: uuid::Uuid,
+) -> Result<Arc<dyn StreamHandler>> {
     use ferrotunnel_observability::dashboard::{create_router, DashboardState, EventBroadcaster};
     use tokio::sync::RwLock;
 
     let dashboard_state = Arc::new(RwLock::new(DashboardState::new(1000)));
     let broadcaster = Arc::new(EventBroadcaster::new(100));
+    let dashboard_config = &args.features.dashboard;
+    let addr = validate_dashboard_config(dashboard_config)?;
+    let auth_token = dashboard_config
+        .auth_token
+        .clone()
+        .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+    let generated_auth_token = dashboard_config.auth_token.is_none();
+    let app = create_router(
+        dashboard_state.clone(),
+        broadcaster.clone(),
+        Some(auth_token.clone()),
+    );
 
-    let app = create_router(dashboard_state.clone(), broadcaster.clone());
-    let addr = std::net::SocketAddr::from(([0, 0, 0, 0], args.features.dashboard.port));
-
-    info!("Starting Dashboard at http://{}", addr);
+    if generated_auth_token {
+        info!(
+            "Starting Dashboard at http://{}; open http://{}?token={} to authenticate",
+            addr, addr, auth_token
+        );
+    } else {
+        info!(
+            "Starting Dashboard at http://{} with API authentication enabled",
+            addr
+        );
+    }
     tokio::spawn(async move {
         match tokio::net::TcpListener::bind(addr).await {
             Ok(listener) => {
@@ -365,7 +411,32 @@ async fn setup_dashboard(args: &ClientArgs, tunnel_id: uuid::Uuid) -> Arc<dyn St
         tunnel_id,
     };
 
-    Arc::new(ferrotunnel_http::HttpProxy::new(args.local_addr.clone()).with_layer(capture_layer))
+    Ok(Arc::new(
+        ferrotunnel_http::HttpProxy::new(args.local_addr.clone()).with_layer(capture_layer),
+    ))
+}
+
+fn validate_dashboard_config(config: &DashboardConfig) -> Result<std::net::SocketAddr> {
+    if matches!(config.auth_token.as_deref(), Some("")) {
+        anyhow::bail!("Dashboard auth token must not be empty");
+    }
+
+    if !config.bind.is_loopback() {
+        if !config.allow_non_loopback {
+            anyhow::bail!(
+                "Refusing to bind dashboard to non-loopback address {}; pass --dashboard-allow-non-loopback to expose it",
+                config.bind
+            );
+        }
+
+        if config.auth_token.is_none() {
+            anyhow::bail!(
+                "Dashboard auth token is required when binding to non-loopback addresses"
+            );
+        }
+    }
+
+    Ok(std::net::SocketAddr::new(config.bind, config.port))
 }
 
 #[cfg(feature = "quic")]
@@ -392,6 +463,16 @@ fn setup_quic_config(args: &ClientArgs) -> ferrotunnel_core::transport::quic::Qu
     }
 }
 
+fn validate_tls_args(args: &ClientArgs) -> Result<()> {
+    if args.features.tls.enabled && !args.features.tls.skip_verify && args.tls_ca.is_none() {
+        anyhow::bail!(
+            "TLS requires --tls-ca for certificate verification; use --tls-skip-verify only for explicit insecure mode"
+        );
+    }
+
+    Ok(())
+}
+
 fn setup_tls(mut client: TunnelClient, args: &ClientArgs) -> TunnelClient {
     if args.features.tls.enabled {
         if args.features.tls.skip_verify {
@@ -400,9 +481,6 @@ fn setup_tls(mut client: TunnelClient, args: &ClientArgs) -> TunnelClient {
         } else if let Some(ref ca_path) = args.tls_ca {
             info!("TLS enabled with CA: {:?}", ca_path);
             client = client.with_tls_ca(ca_path.clone());
-        } else {
-            info!("TLS enabled with certificate verification skipped (no CA provided)");
-            client = client.with_tls_skip_verify();
         }
 
         if let Some(ref server_name) = args.tls_server_name {
@@ -419,4 +497,145 @@ fn setup_tls(mut client: TunnelClient, args: &ClientArgs) -> TunnelClient {
         }
     }
     client
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn client_args(tls_enabled: bool, skip_verify: bool, tls_ca: Option<PathBuf>) -> ClientArgs {
+        ClientArgs {
+            server: "127.0.0.1:7835".to_string(),
+            token: Some("token".to_string()),
+            log_level: "info".to_string(),
+            local_addr: "127.0.0.1:8000".to_string(),
+            tunnel_id: None,
+            features: ClientFeatureArgs {
+                dashboard: DashboardConfig {
+                    port: 4040,
+                    bind: std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
+                    allow_non_loopback: false,
+                    auth_token: None,
+                    disabled: true,
+                },
+                tls: TlsConfig {
+                    enabled: tls_enabled,
+                    skip_verify,
+                },
+                telemetry: TelemetryConfig {
+                    observability: false,
+                    metrics: false,
+                },
+            },
+            tls_ca,
+            tls_server_name: None,
+            tls_cert: None,
+            tls_key: None,
+            #[cfg(feature = "quic")]
+            quic: false,
+            #[cfg(feature = "quic")]
+            quic_0rtt: false,
+        }
+    }
+
+    #[test]
+    fn dashboard_allows_loopback_by_default() {
+        let config = DashboardConfig {
+            port: 4040,
+            bind: std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
+            allow_non_loopback: false,
+            auth_token: None,
+            disabled: false,
+        };
+
+        let addr = validate_dashboard_config(&config).expect("loopback bind should be allowed");
+
+        assert!(addr.ip().is_loopback());
+    }
+
+    #[test]
+    fn dashboard_rejects_non_loopback_without_explicit_opt_in() {
+        let config = DashboardConfig {
+            port: 4040,
+            bind: std::net::IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED),
+            allow_non_loopback: false,
+            auth_token: None,
+            disabled: false,
+        };
+
+        let err = validate_dashboard_config(&config).expect_err("non-loopback bind must fail");
+
+        assert!(err.to_string().contains("--dashboard-allow-non-loopback"));
+    }
+
+    #[test]
+    fn dashboard_rejects_non_loopback_without_auth_token() {
+        let config = DashboardConfig {
+            port: 4040,
+            bind: std::net::IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED),
+            allow_non_loopback: true,
+            auth_token: None,
+            disabled: false,
+        };
+
+        let err = validate_dashboard_config(&config).expect_err("exposed bind must require auth");
+
+        assert!(err.to_string().contains("auth token"));
+    }
+
+    #[test]
+    fn dashboard_allows_non_loopback_with_explicit_opt_in() {
+        let config = DashboardConfig {
+            port: 4040,
+            bind: std::net::IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED),
+            allow_non_loopback: true,
+            auth_token: Some("secret".to_string()),
+            disabled: false,
+        };
+
+        let addr =
+            validate_dashboard_config(&config).expect("explicit opt-in should allow exposed bind");
+
+        assert!(!addr.ip().is_loopback());
+    }
+
+    #[test]
+    fn dashboard_rejects_empty_auth_token() {
+        let config = DashboardConfig {
+            port: 4040,
+            bind: std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
+            allow_non_loopback: false,
+            auth_token: Some(String::new()),
+            disabled: false,
+        };
+
+        let err = validate_dashboard_config(&config).expect_err("empty auth token must fail");
+
+        assert!(err.to_string().contains("must not be empty"));
+    }
+
+    #[test]
+    fn tls_without_ca_requires_explicit_insecure_mode() {
+        let args = client_args(true, false, None);
+
+        let err = validate_tls_args(&args).expect_err("TLS without CA must fail");
+
+        assert!(err.to_string().contains("--tls-ca"));
+        assert!(err.to_string().contains("--tls-skip-verify"));
+    }
+
+    #[test]
+    fn tls_allows_explicit_skip_verify_without_ca() {
+        let args = client_args(true, true, None);
+
+        validate_tls_args(&args).expect("explicit insecure mode should be allowed");
+    }
+
+    #[test]
+    fn tls_allows_ca_without_skip_verify() {
+        let args = client_args(true, false, Some(PathBuf::from("ca.crt")));
+
+        validate_tls_args(&args).expect("CA-backed TLS should be allowed");
+    }
 }

--- a/ferrotunnel-cli/src/commands/server.rs
+++ b/ferrotunnel-cli/src/commands/server.rs
@@ -1,13 +1,13 @@
 //! Server subcommand implementation
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use clap::Args;
 use ferrotunnel_core::TunnelServer;
 use ferrotunnel_observability::{
     gather_metrics, init_basic_observability, init_minimal_logging, shutdown_tracing,
 };
 use std::net::SocketAddr;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use tracing::{error, info};
 
 #[derive(Args, Debug)]
@@ -16,9 +16,13 @@ pub struct ServerArgs {
     #[arg(long, default_value = "0.0.0.0:7835", env = "FERROTUNNEL_BIND")]
     bind: SocketAddr,
 
-    /// Authentication token
-    #[arg(long, env = "FERROTUNNEL_TOKEN")]
-    token: String,
+    /// Authentication token. If omitted, uses FERROTUNNEL_TOKEN, --token-file, or prompts securely.
+    #[arg(long, env = "FERROTUNNEL_TOKEN", hide_env_values = true)]
+    token: Option<String>,
+
+    /// Read the authentication token from a file. Trailing newlines are ignored.
+    #[arg(long, env = "FERROTUNNEL_TOKEN_FILE")]
+    token_file: Option<PathBuf>,
 
     /// Log level
     #[arg(long, default_value = "info", env = "RUST_LOG")]
@@ -91,6 +95,32 @@ pub struct ServerArgs {
     quic_key: Option<PathBuf>,
 }
 
+/// Resolve token from args, then env, then token file, then secure prompt.
+fn resolve_token(args: &ServerArgs) -> Result<String> {
+    if let Some(ref t) = args.token {
+        return Ok(t.clone());
+    }
+    if let Ok(t) = std::env::var("FERROTUNNEL_TOKEN") {
+        return Ok(t);
+    }
+    if let Some(ref path) = args.token_file {
+        return read_token_file(path);
+    }
+    prompt_token()
+}
+
+fn read_token_file(path: &Path) -> Result<String> {
+    let token = std::fs::read_to_string(path)
+        .with_context(|| format!("Could not read token file {}", path.display()))?;
+    Ok(token.trim_end_matches(['\r', '\n']).to_owned())
+}
+
+/// Prompt for token on TTY without echoing (secure input).
+fn prompt_token() -> Result<String> {
+    rpassword::prompt_password("Token: ")
+        .context("Could not read token from terminal (is stdin a TTY?). Set FERROTUNNEL_TOKEN, pass --token-file, or pass --token")
+}
+
 #[allow(clippy::too_many_lines)]
 pub async fn run(args: ServerArgs) -> Result<()> {
     let enable_tracing = args.observability;
@@ -124,7 +154,8 @@ pub async fn run(args: ServerArgs) -> Result<()> {
 
     info!("Starting FerroTunnel Server v{}", env!("CARGO_PKG_VERSION"));
 
-    let mut server = TunnelServer::new(args.bind, args.token.clone());
+    let token = resolve_token(&args)?;
+    let mut server = TunnelServer::new(args.bind, token.clone());
 
     if let (Some(cert_path), Some(key_path)) = (&args.tls_cert, &args.tls_key) {
         info!(
@@ -158,7 +189,7 @@ pub async fn run(args: ServerArgs) -> Result<()> {
 
     // 2. Token Auth
     registry.register(std::sync::Arc::new(tokio::sync::RwLock::new(
-        ferrotunnel_plugin::builtin::TokenAuthPlugin::new(vec![args.token.clone()]),
+        ferrotunnel_plugin::builtin::TokenAuthPlugin::new(vec![token.clone()]),
     )));
 
     let registry = std::sync::Arc::new(registry);
@@ -190,12 +221,14 @@ pub async fn run(args: ServerArgs) -> Result<()> {
     };
 
     info!("Starting HTTP Ingress on {}", args.http_bind);
-    let mut http_ingress =
+    let http_ingress =
         ferrotunnel_http::HttpIngress::new(args.http_bind, sessions.clone(), registry.clone());
     #[cfg(feature = "http3")]
-    if let Some((_, _, Some(alt_svc))) = &http3_start {
-        http_ingress = http_ingress.with_alt_svc_header(alt_svc.clone());
-    }
+    let http_ingress = if let Some((_, _, Some(alt_svc))) = &http3_start {
+        http_ingress.with_alt_svc_header(alt_svc.clone())
+    } else {
+        http_ingress
+    };
     let http_handle = tokio::spawn(async move { http_ingress.start().await });
 
     // Start TCP Ingress (if enabled)
@@ -238,7 +271,7 @@ pub async fn run(args: ServerArgs) -> Result<()> {
                     .map(|p| p.to_string_lossy().to_string()),
                 ..Default::default()
             };
-            let quic_server = TunnelServer::new(args.bind, args.token.clone())
+            let quic_server = TunnelServer::new(args.bind, token.clone())
                 .with_transport(ferrotunnel_core::transport::TransportConfig::Quic(
                     quic_config,
                 ))
@@ -299,4 +332,27 @@ pub async fn run(args: ServerArgs) -> Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[test]
+    fn read_token_file_trims_trailing_line_endings() {
+        let path = std::env::temp_dir().join(format!(
+            "ferrotunnel-token-test-{}",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("system time should be after Unix epoch")
+                .as_nanos()
+        ));
+        std::fs::write(&path, "secret\r\n\n").expect("token test file should be writable");
+
+        let token = read_token_file(&path).expect("token file should be readable");
+        let _ = std::fs::remove_file(&path);
+
+        assert_eq!(token, "secret");
+    }
 }

--- a/ferrotunnel-cli/src/commands/server.rs
+++ b/ferrotunnel-cli/src/commands/server.rs
@@ -99,7 +99,7 @@ pub struct ServerArgs {
 /// `--token-file`, or the interactive TTY prompt instead.
 fn resolve_token(args: &ServerArgs) -> Result<String> {
     if let Ok(t) = std::env::var("FERROTUNNEL_TOKEN") {
-        return Ok(t);
+        return Ok(t.trim_end_matches(['\r', '\n']).to_owned());
     }
     if let Some(ref path) = args.token_file {
         return read_token_file(path);

--- a/ferrotunnel-cli/src/commands/server.rs
+++ b/ferrotunnel-cli/src/commands/server.rs
@@ -16,10 +16,6 @@ pub struct ServerArgs {
     #[arg(long, default_value = "0.0.0.0:7835", env = "FERROTUNNEL_BIND")]
     bind: SocketAddr,
 
-    /// Authentication token. If omitted, uses FERROTUNNEL_TOKEN, --token-file, or prompts securely.
-    #[arg(long, env = "FERROTUNNEL_TOKEN", hide_env_values = true)]
-    token: Option<String>,
-
     /// Read the authentication token from a file. Trailing newlines are ignored.
     #[arg(long, env = "FERROTUNNEL_TOKEN_FILE")]
     token_file: Option<PathBuf>,
@@ -95,11 +91,13 @@ pub struct ServerArgs {
     quic_key: Option<PathBuf>,
 }
 
-/// Resolve token from args, then env, then token file, then secure prompt.
+/// Resolve token from env, then token file, then secure prompt.
+///
+/// The token is deliberately not accepted as a command-line flag: a `--token`
+/// argument would be visible to any local user via the process list (`ps`) and
+/// could leak into shell history. Supply it via `FERROTUNNEL_TOKEN`,
+/// `--token-file`, or the interactive TTY prompt instead.
 fn resolve_token(args: &ServerArgs) -> Result<String> {
-    if let Some(ref t) = args.token {
-        return Ok(t.clone());
-    }
     if let Ok(t) = std::env::var("FERROTUNNEL_TOKEN") {
         return Ok(t);
     }
@@ -118,7 +116,7 @@ fn read_token_file(path: &Path) -> Result<String> {
 /// Prompt for token on TTY without echoing (secure input).
 fn prompt_token() -> Result<String> {
     rpassword::prompt_password("Token: ")
-        .context("Could not read token from terminal (is stdin a TTY?). Set FERROTUNNEL_TOKEN, pass --token-file, or pass --token")
+        .context("Could not read token from terminal (is stdin a TTY?). Set FERROTUNNEL_TOKEN or pass --token-file")
 }
 
 #[allow(clippy::too_many_lines)]

--- a/ferrotunnel-common/Cargo.toml
+++ b/ferrotunnel-common/Cargo.toml
@@ -16,5 +16,8 @@ uuid = { workspace = true }
 serde = { workspace = true }
 bincode-next = { workspace = true }
 
+[dev-dependencies]
+serde_json = "1"
+
 [lints]
 workspace = true

--- a/ferrotunnel-common/src/config.rs
+++ b/ferrotunnel-common/src/config.rs
@@ -23,6 +23,10 @@ pub struct TlsConfig {
     /// Enabling this leaves TLS connections unauthenticated and vulnerable to
     /// man-in-the-middle interception. Client config builders emit a warning
     /// whenever this is used.
+    ///
+    /// Defaults to `false` so older config files that predate this field
+    /// deserialize without error and keep verification enabled.
+    #[serde(default)]
     pub skip_verify: bool,
 }
 
@@ -104,5 +108,47 @@ pub struct QuicConfig {
     /// Enabling this leaves QUIC connections unauthenticated and vulnerable to
     /// man-in-the-middle interception. Client config builders emit a warning
     /// whenever this is used.
+    ///
+    /// Defaults to `false` so older config files that predate this field
+    /// deserialize without error and keep verification enabled.
+    #[serde(default)]
     pub skip_verify: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tls_config_without_skip_verify_defaults_to_secure() {
+        // Simulates a config file written before `skip_verify` existed.
+        let json = r#"{ "enabled": true, "client_auth": false }"#;
+        let config: TlsConfig =
+            serde_json::from_str(json).expect("legacy TLS config must still deserialize");
+        assert!(
+            !config.skip_verify,
+            "missing skip_verify must default to false (verification enabled)"
+        );
+        assert!(config.enabled);
+    }
+
+    #[test]
+    fn quic_config_without_skip_verify_defaults_to_secure() {
+        let json = r#"{ "enabled": true, "enable_0rtt": false }"#;
+        let config: QuicConfig =
+            serde_json::from_str(json).expect("legacy QUIC config must still deserialize");
+        assert!(
+            !config.skip_verify,
+            "missing skip_verify must default to false (verification enabled)"
+        );
+        assert!(config.enabled);
+    }
+
+    #[test]
+    fn skip_verify_round_trips_when_present() {
+        let json = r#"{ "enabled": true, "client_auth": false, "skip_verify": true }"#;
+        let config: TlsConfig =
+            serde_json::from_str(json).expect("config with skip_verify must deserialize");
+        assert!(config.skip_verify);
+    }
 }

--- a/ferrotunnel-common/src/config.rs
+++ b/ferrotunnel-common/src/config.rs
@@ -18,6 +18,12 @@ pub struct TlsConfig {
     pub server_name: Option<String>,
     /// Require client certificate authentication
     pub client_auth: bool,
+    /// Skip certificate verification (insecure, for self-signed certs only).
+    ///
+    /// Enabling this leaves TLS connections unauthenticated and vulnerable to
+    /// man-in-the-middle interception. Client config builders emit a warning
+    /// whenever this is used.
+    pub skip_verify: bool,
 }
 
 /// Resource limits configuration
@@ -93,6 +99,10 @@ pub struct QuicConfig {
     pub max_idle_timeout_secs: Option<u64>,
     /// Keep-alive interval in seconds (default: 10)
     pub keep_alive_interval_secs: Option<u64>,
-    /// Skip certificate verification (insecure, for self-signed certs)
+    /// Skip certificate verification (insecure, for self-signed certs only).
+    ///
+    /// Enabling this leaves QUIC connections unauthenticated and vulnerable to
+    /// man-in-the-middle interception. Client config builders emit a warning
+    /// whenever this is used.
     pub skip_verify: bool,
 }

--- a/ferrotunnel-core/Cargo.toml
+++ b/ferrotunnel-core/Cargo.toml
@@ -12,8 +12,8 @@ keywords = ["tunnel", "networking", "async", "core"]
 categories = ["network-programming", "asynchronous"]
 
 [dependencies]
-ferrotunnel-common = { version = "1.0.8", path = "../ferrotunnel-common" }
-ferrotunnel-protocol = { version = "1.0.8", path = "../ferrotunnel-protocol" }
+ferrotunnel-common = { version = "1.1.0", path = "../ferrotunnel-common" }
+ferrotunnel-protocol = { version = "1.1.0", path = "../ferrotunnel-protocol" }
 
 tokio = { workspace = true }
 tokio-util = { workspace = true }
@@ -54,7 +54,7 @@ crossbeam-queue = "0.3"
 quinn = { workspace = true, optional = true }
 
 # Optional metrics (decode/encode latency, queue depth)
-ferrotunnel-observability = { version = "1.0.8", path = "../ferrotunnel-observability", optional = true }
+ferrotunnel-observability = { version = "1.1.0", path = "../ferrotunnel-observability", optional = true }
 
 [features]
 default = []

--- a/ferrotunnel-core/src/auth.rs
+++ b/ferrotunnel-core/src/auth.rs
@@ -7,13 +7,20 @@ use subtle::ConstantTimeEq;
 /// Returns true if slices are equal, false otherwise
 ///
 /// This prevents timing attacks where an attacker could determine
-/// how many bytes match based on comparison time.
+/// how many bytes match based on comparison time. The comparison runs
+/// over `max(a.len(), b.len())` bytes and folds the length check into the
+/// result, so it does not short-circuit on a length mismatch and therefore
+/// does not leak the expected length through timing.
 #[must_use]
 pub fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
-    if a.len() != b.len() {
-        return false;
+    let max_len = a.len().max(b.len());
+    let mut matches = a.len().ct_eq(&b.len());
+    for index in 0..max_len {
+        let left = a.get(index).copied().unwrap_or(0);
+        let right = b.get(index).copied().unwrap_or(0);
+        matches &= left.ct_eq(&right);
     }
-    a.ct_eq(b).into()
+    matches.into()
 }
 
 /// Hash a token using SHA-256

--- a/ferrotunnel-core/src/transport/quic.rs
+++ b/ferrotunnel-core/src/transport/quic.rs
@@ -90,6 +90,13 @@ impl QuicTransportConfig {
 
 /// Create a quinn `ClientConfig` by reusing the existing rustls TLS config infrastructure.
 pub fn create_quinn_client_config(config: &QuicTransportConfig) -> io::Result<ClientConfig> {
+    create_quinn_client_config_with_target(config, config.server_name.as_deref())
+}
+
+fn create_quinn_client_config_with_target(
+    config: &QuicTransportConfig,
+    server_name: Option<&str>,
+) -> io::Result<ClientConfig> {
     // Reuse TLS config creation from tls.rs
     let tls_config = tls::TlsTransportConfig {
         ca_cert_path: config.ca_cert_path.clone(),
@@ -100,7 +107,7 @@ pub fn create_quinn_client_config(config: &QuicTransportConfig) -> io::Result<Cl
         skip_verify: config.skip_verify,
     };
 
-    let rustls_config = tls::create_client_config(&tls_config)?;
+    let rustls_config = tls::create_client_config_with_context(&tls_config, "QUIC", server_name)?;
 
     let mut transport = quinn::TransportConfig::default();
     transport.max_idle_timeout(Some(config.max_idle_timeout.try_into().map_err(|e| {
@@ -152,7 +159,14 @@ pub fn create_quinn_server_config(config: &QuicTransportConfig) -> io::Result<Se
 
 /// Create a client endpoint bound to an ephemeral UDP port.
 pub fn create_client_endpoint(config: &QuicTransportConfig) -> io::Result<Endpoint> {
-    let client_config = create_quinn_client_config(config)?;
+    create_client_endpoint_with_target(config, config.server_name.as_deref())
+}
+
+fn create_client_endpoint_with_target(
+    config: &QuicTransportConfig,
+    server_name: Option<&str>,
+) -> io::Result<Endpoint> {
+    let client_config = create_quinn_client_config_with_target(config, server_name)?;
     let mut endpoint = Endpoint::client(
         "0.0.0.0:0"
             .parse()
@@ -180,8 +194,6 @@ pub async fn connect(
     addr: &str,
     config: &QuicTransportConfig,
 ) -> io::Result<(Endpoint, quinn::Connection)> {
-    let endpoint = create_client_endpoint(config)?;
-
     let (host, port) = split_host_port(addr)?;
     let socket_addr = tokio::net::lookup_host((host.as_str(), port))
         .await?
@@ -189,6 +201,7 @@ pub async fn connect(
         .ok_or_else(|| io::Error::new(ErrorKind::AddrNotAvailable, "address resolution failed"))?;
 
     let server_name = config.server_name.clone().unwrap_or(host);
+    let endpoint = create_client_endpoint_with_target(config, Some(&server_name))?;
 
     // Validate server name
     let _: ServerName<'_> = ServerName::try_from(server_name.as_str()).map_err(|e| {

--- a/ferrotunnel-core/src/transport/tls.rs
+++ b/ferrotunnel-core/src/transport/tls.rs
@@ -46,7 +46,7 @@ impl TlsTransportConfig {
                 .unwrap_or_default(),
             server_name: config.server_name.clone(),
             client_auth: config.client_auth,
-            skip_verify: false,
+            skip_verify: config.skip_verify,
         })
     }
 }
@@ -113,9 +113,18 @@ impl rustls::client::danger::ServerCertVerifier for InsecureServerCertVerifier {
 }
 
 pub fn create_client_config(config: &TlsTransportConfig) -> io::Result<Arc<ClientConfig>> {
+    create_client_config_with_context(config, "TLS", config.server_name.as_deref())
+}
+
+pub(crate) fn create_client_config_with_context(
+    config: &TlsTransportConfig,
+    transport: &'static str,
+    server_name: Option<&str>,
+) -> io::Result<Arc<ClientConfig>> {
     let builder = ClientConfig::builder();
 
     let builder = if config.skip_verify {
+        warn_insecure_verification(transport, server_name);
         builder
             .dangerous()
             .with_custom_certificate_verifier(Arc::new(InsecureServerCertVerifier))
@@ -148,6 +157,15 @@ pub fn create_client_config(config: &TlsTransportConfig) -> io::Result<Arc<Clien
     };
 
     Ok(Arc::new(client_config))
+}
+
+fn warn_insecure_verification(transport: &'static str, server_name: Option<&str>) {
+    let server_name = server_name.unwrap_or("<runtime server name>");
+    tracing::warn!(
+        transport,
+        server_name,
+        "certificate verification is disabled; peer identity will not be authenticated"
+    );
 }
 
 pub fn create_server_config(config: &TlsTransportConfig) -> io::Result<Arc<ServerConfig>> {
@@ -190,19 +208,23 @@ pub fn create_server_config(config: &TlsTransportConfig) -> io::Result<Arc<Serve
 }
 
 pub async fn connect(addr: &str, config: &TlsTransportConfig) -> io::Result<BoxedStream> {
-    let client_config = create_client_config(config)?;
+    let configured_server_name = config.server_name.is_some();
+    let server_name = config
+        .server_name
+        .clone()
+        .unwrap_or_else(|| addr.split(':').next().unwrap_or("localhost").to_string());
+    let client_config = create_client_config_with_context(config, "TLS", Some(&server_name))?;
     let connector = TlsConnector::from(client_config);
 
     let tcp_stream = TcpStream::connect(addr).await?;
     configure_socket_silent(&tcp_stream);
 
-    let server_name = if let Some(name) = &config.server_name {
-        ServerName::try_from(name.clone()).map_err(|e| {
+    let server_name = if configured_server_name {
+        ServerName::try_from(server_name).map_err(|e| {
             io::Error::new(ErrorKind::InvalidInput, format!("invalid server name: {e}"))
         })?
     } else {
-        let host = addr.split(':').next().unwrap_or("localhost");
-        ServerName::try_from(host.to_string()).map_err(|e| {
+        ServerName::try_from(server_name).map_err(|e| {
             io::Error::new(
                 ErrorKind::InvalidInput,
                 format!("invalid host in address '{}': {}", addr, e),
@@ -221,4 +243,25 @@ pub async fn accept_tls(
     let server_config = create_server_config(config)?;
     let acceptor = TlsAcceptor::from(server_config);
     acceptor.accept(tcp_stream).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::TlsTransportConfig;
+    use ferrotunnel_common::config::TlsConfig;
+
+    #[test]
+    fn from_common_preserves_skip_verify() {
+        let config = TlsConfig {
+            enabled: true,
+            skip_verify: true,
+            server_name: Some("localhost".to_string()),
+            ..Default::default()
+        };
+
+        let tls = TlsTransportConfig::from_common(&config).expect("TLS should be enabled");
+
+        assert!(tls.skip_verify);
+        assert_eq!(tls.server_name.as_deref(), Some("localhost"));
+    }
 }

--- a/ferrotunnel-core/src/transport/tls.rs
+++ b/ferrotunnel-core/src/transport/tls.rs
@@ -219,18 +219,14 @@ pub async fn connect(addr: &str, config: &TlsTransportConfig) -> io::Result<Boxe
     let tcp_stream = TcpStream::connect(addr).await?;
     configure_socket_silent(&tcp_stream);
 
-    let server_name = if configured_server_name {
-        ServerName::try_from(server_name).map_err(|e| {
-            io::Error::new(ErrorKind::InvalidInput, format!("invalid server name: {e}"))
-        })?
-    } else {
-        ServerName::try_from(server_name).map_err(|e| {
-            io::Error::new(
-                ErrorKind::InvalidInput,
-                format!("invalid host in address '{}': {}", addr, e),
-            )
-        })?
-    };
+    let server_name = ServerName::try_from(server_name).map_err(|e| {
+        let message = if configured_server_name {
+            format!("invalid server name: {e}")
+        } else {
+            format!("invalid host in address '{addr}': {e}")
+        };
+        io::Error::new(ErrorKind::InvalidInput, message)
+    })?;
 
     let tls_stream = connector.connect(server_name, tcp_stream).await?;
     Ok(Box::pin(tls_stream))

--- a/ferrotunnel-core/src/tunnel/client.rs
+++ b/ferrotunnel-core/src/tunnel/client.rs
@@ -2,16 +2,16 @@ use crate::auth::validate_token_format;
 use crate::stream::{Multiplexer, PrioritizedFrame, VirtualStream};
 use crate::transport::batched_sender::run_batched_sender;
 use crate::transport::{self, TransportConfig};
-use crate::tunnel::common::clamp_u128_to_u64;
+use crate::tunnel::common::{clamp_u128_to_u64, read_initial_handshake_frame};
 use ferrotunnel_common::{Result, TunnelError};
 use ferrotunnel_protocol::codec::TunnelCodec;
 use ferrotunnel_protocol::constants::{MAX_PROTOCOL_VERSION, MIN_PROTOCOL_VERSION};
 use ferrotunnel_protocol::frame::{Frame, HandshakeFrame, HandshakeStatus};
-use futures::{SinkExt, Stream, StreamExt};
+use futures::{SinkExt, StreamExt};
 use kanal::bounded_async;
 use std::future::Future;
 use std::time::{Duration, Instant};
-use tokio::time::{interval, timeout};
+use tokio::time::interval;
 use tokio_util::codec::Framed;
 use tracing::{error, info};
 use uuid::Uuid;
@@ -357,27 +357,6 @@ impl TunnelClient {
             }
         }
     }
-}
-
-async fn read_initial_handshake_frame<S>(
-    framed: &mut S,
-    handshake_timeout: Duration,
-    context: &str,
-) -> Result<Frame>
-where
-    S: Stream<Item = std::io::Result<Frame>> + Unpin,
-{
-    let result = timeout(handshake_timeout, framed.next())
-        .await
-        .map_err(|_| {
-            TunnelError::Timeout(format!(
-                "{context} handshake timed out after {handshake_timeout:?}"
-            ))
-        })?;
-
-    result
-        .ok_or_else(|| TunnelError::Connection(format!("{context} handshake stream closed")))?
-        .map_err(TunnelError::Io)
 }
 
 impl TunnelClient {

--- a/ferrotunnel-core/src/tunnel/client.rs
+++ b/ferrotunnel-core/src/tunnel/client.rs
@@ -7,11 +7,11 @@ use ferrotunnel_common::{Result, TunnelError};
 use ferrotunnel_protocol::codec::TunnelCodec;
 use ferrotunnel_protocol::constants::{MAX_PROTOCOL_VERSION, MIN_PROTOCOL_VERSION};
 use ferrotunnel_protocol::frame::{Frame, HandshakeFrame, HandshakeStatus};
-use futures::{SinkExt, StreamExt};
+use futures::{SinkExt, Stream, StreamExt};
 use kanal::bounded_async;
 use std::future::Future;
 use std::time::{Duration, Instant};
-use tokio::time::interval;
+use tokio::time::{interval, timeout};
 use tokio_util::codec::Framed;
 use tracing::{error, info};
 use uuid::Uuid;
@@ -21,12 +21,15 @@ use crate::stream::QuicVirtualStream;
 #[cfg(feature = "quic")]
 use crate::transport::quic;
 
+const DEFAULT_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
+
 pub struct TunnelClient {
     server_addr: String,
     auth_token: String,
     session_id: Option<Uuid>,
     tunnel_id: Option<String>,
     transport_config: TransportConfig,
+    handshake_timeout: Duration,
 }
 
 impl TunnelClient {
@@ -37,6 +40,7 @@ impl TunnelClient {
             session_id: None,
             tunnel_id: None,
             transport_config: TransportConfig::default(),
+            handshake_timeout: DEFAULT_HANDSHAKE_TIMEOUT,
         }
     }
 
@@ -49,6 +53,12 @@ impl TunnelClient {
     #[must_use]
     pub fn with_tunnel_id(mut self, tunnel_id: impl Into<String>) -> Self {
         self.tunnel_id = Some(tunnel_id.into());
+        self
+    }
+
+    #[must_use]
+    pub fn with_handshake_timeout(mut self, timeout: Duration) -> Self {
+        self.handshake_timeout = timeout;
         self
     }
 
@@ -222,13 +232,28 @@ impl TunnelClient {
             })))
             .await?;
 
-        let session_id = match ctrl_framed_recv.next().await {
-            Some(Ok(Frame::HandshakeAck {
+        let frame = match read_initial_handshake_frame(
+            &mut ctrl_framed_recv,
+            self.handshake_timeout,
+            "QUIC client",
+        )
+        .await
+        {
+            Ok(frame) => frame,
+            Err(err @ TunnelError::Timeout(_)) => {
+                connection.close(quinn::VarInt::from_u32(0), b"handshake timeout");
+                return Err(err);
+            }
+            Err(err) => return Err(err),
+        };
+
+        let session_id = match frame {
+            Frame::HandshakeAck {
                 status,
                 session_id,
                 version,
                 server_capabilities: _,
-            })) => match status {
+            } => match status {
                 HandshakeStatus::Success => {
                     info!(
                         "QUIC handshake successful. Session ID: {}, Protocol v{}",
@@ -248,14 +273,8 @@ impl TunnelClient {
                     )));
                 }
             },
-            Some(Ok(_)) => {
+            _ => {
                 return Err(TunnelError::Protocol("Expected HandshakeAck".into()));
-            }
-            Some(Err(e)) => {
-                return Err(TunnelError::Io(e));
-            }
-            None => {
-                return Err(TunnelError::Connection("Connection closed".into()));
             }
         };
 
@@ -340,6 +359,27 @@ impl TunnelClient {
     }
 }
 
+async fn read_initial_handshake_frame<S>(
+    framed: &mut S,
+    handshake_timeout: Duration,
+    context: &str,
+) -> Result<Frame>
+where
+    S: Stream<Item = std::io::Result<Frame>> + Unpin,
+{
+    let result = timeout(handshake_timeout, framed.next())
+        .await
+        .map_err(|_| {
+            TunnelError::Timeout(format!(
+                "{context} handshake timed out after {handshake_timeout:?}"
+            ))
+        })?;
+
+    result
+        .ok_or_else(|| TunnelError::Connection(format!("{context} handshake stream closed")))?
+        .map_err(TunnelError::Io)
+}
+
 impl TunnelClient {
     async fn handshake<C>(
         framed: &mut Framed<transport::BoxedStream, TunnelCodec>,
@@ -359,39 +399,37 @@ impl TunnelClient {
             })))
             .await?;
 
-        if let Some(result) = framed.next().await {
-            match result? {
-                Frame::HandshakeAck {
-                    status,
-                    session_id,
-                    version,
-                    server_capabilities: _,
-                } => match status {
-                    HandshakeStatus::Success => {
-                        info!(
-                            "Handshake successful. Session ID: {}, Protocol v{}",
-                            session_id, version
-                        );
-                        on_connected(session_id);
-                        Ok(session_id)
-                    }
-                    HandshakeStatus::VersionMismatch => {
-                        error!("Protocol version mismatch. Server requires different version.");
-                        Err(TunnelError::Protocol(
-                            "No compatible protocol version found".into(),
-                        ))
-                    }
-                    status => {
-                        error!("Handshake failed: {:?}", status);
-                        Err(TunnelError::Authentication(format!(
-                            "Handshake rejected: {status:?}"
-                        )))
-                    }
-                },
-                _ => Err(TunnelError::Protocol("Expected HandshakeAck".into())),
-            }
-        } else {
-            Err(TunnelError::Connection("Connection closed".into()))
+        let frame =
+            read_initial_handshake_frame(framed, client.handshake_timeout, "client").await?;
+        match frame {
+            Frame::HandshakeAck {
+                status,
+                session_id,
+                version,
+                server_capabilities: _,
+            } => match status {
+                HandshakeStatus::Success => {
+                    info!(
+                        "Handshake successful. Session ID: {}, Protocol v{}",
+                        session_id, version
+                    );
+                    on_connected(session_id);
+                    Ok(session_id)
+                }
+                HandshakeStatus::VersionMismatch => {
+                    error!("Protocol version mismatch. Server requires different version.");
+                    Err(TunnelError::Protocol(
+                        "No compatible protocol version found".into(),
+                    ))
+                }
+                status => {
+                    error!("Handshake failed: {:?}", status);
+                    Err(TunnelError::Authentication(format!(
+                        "Handshake rejected: {status:?}"
+                    )))
+                }
+            },
+            _ => Err(TunnelError::Protocol("Expected HandshakeAck".into())),
         }
     }
 
@@ -487,5 +525,23 @@ impl TunnelClient {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn handshake_read_times_out_for_silent_peer() {
+        let mut stream = futures::stream::pending::<std::io::Result<Frame>>();
+        let err = read_initial_handshake_frame(&mut stream, Duration::from_millis(1), "client")
+            .await
+            .unwrap_err();
+
+        assert!(matches!(
+            err,
+            TunnelError::Timeout(msg) if msg.contains("client handshake timed out")
+        ));
     }
 }

--- a/ferrotunnel-core/src/tunnel/common.rs
+++ b/ferrotunnel-core/src/tunnel/common.rs
@@ -1,3 +1,34 @@
+use ferrotunnel_common::{Result, TunnelError};
+use ferrotunnel_protocol::frame::Frame;
+use futures::{Stream, StreamExt};
+use std::time::Duration;
+use tokio::time::timeout;
+
 pub fn clamp_u128_to_u64(i: u128) -> u64 {
     i.min(u128::from(u64::MAX)) as u64
+}
+
+/// Read the first frame of a handshake, enforcing a timeout.
+///
+/// Shared by the client and server handshake paths. `context` is used only to
+/// disambiguate the error messages (e.g. `"client"` / `"server"`).
+pub(crate) async fn read_initial_handshake_frame<S>(
+    framed: &mut S,
+    handshake_timeout: Duration,
+    context: &str,
+) -> Result<Frame>
+where
+    S: Stream<Item = std::io::Result<Frame>> + Unpin,
+{
+    let result = timeout(handshake_timeout, framed.next())
+        .await
+        .map_err(|_| {
+            TunnelError::Timeout(format!(
+                "{context} handshake timed out after {handshake_timeout:?}"
+            ))
+        })?;
+
+    result
+        .ok_or_else(|| TunnelError::Connection(format!("{context} handshake stream closed")))?
+        .map_err(TunnelError::Io)
 }

--- a/ferrotunnel-core/src/tunnel/server.rs
+++ b/ferrotunnel-core/src/tunnel/server.rs
@@ -9,11 +9,12 @@ use ferrotunnel_common::{Result, TunnelError};
 use ferrotunnel_protocol::codec::TunnelCodec;
 use ferrotunnel_protocol::constants::{MAX_PROTOCOL_VERSION, MIN_PROTOCOL_VERSION};
 use ferrotunnel_protocol::frame::{Frame, HandshakeFrame, HandshakeStatus};
-use futures::{SinkExt, StreamExt};
+use futures::{SinkExt, Stream, StreamExt};
 use kanal::bounded_async;
 use std::net::SocketAddr;
 use std::time::{Duration, Instant};
 use tokio::net::TcpListener;
+use tokio::time::timeout;
 use tokio_util::codec::Framed;
 use tracing::{error, info, warn};
 use uuid::Uuid;
@@ -23,11 +24,14 @@ use crate::stream::QuicMultiplexer;
 #[cfg(feature = "quic")]
 use crate::transport::quic;
 
+const DEFAULT_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
+
 pub struct TunnelServer {
     addr: SocketAddr,
     auth_token: String,
     sessions: SessionStoreBackend,
     session_timeout: Duration,
+    handshake_timeout: Duration,
     resource_limits: ServerResourceLimits,
     transport_config: TransportConfig,
 }
@@ -39,6 +43,7 @@ impl TunnelServer {
             auth_token,
             sessions: SessionStoreBackend::default(),
             session_timeout: Duration::from_secs(90),
+            handshake_timeout: DEFAULT_HANDSHAKE_TIMEOUT,
             resource_limits: ServerResourceLimits::default(),
             transport_config: TransportConfig::default(),
         }
@@ -54,6 +59,12 @@ impl TunnelServer {
     #[must_use]
     pub fn with_resource_limits(mut self, limits: ServerResourceLimits) -> Self {
         self.resource_limits = limits;
+        self
+    }
+
+    #[must_use]
+    pub fn with_handshake_timeout(mut self, timeout: Duration) -> Self {
+        self.handshake_timeout = timeout;
         self
     }
 
@@ -122,6 +133,7 @@ impl TunnelServer {
 
         let sessions = self.sessions.clone();
         let timeout = self.session_timeout;
+        let handshake_timeout = self.handshake_timeout;
 
         // Spawn session cleanup task
         let cleanup_sessions = sessions.clone();
@@ -151,9 +163,15 @@ impl TunnelServer {
                     let token = self.auth_token.clone();
 
                     tokio::spawn(async move {
-                        if let Err(e) =
-                            Self::handle_connection(stream, addr, sessions, token, session_permit)
-                                .await
+                        if let Err(e) = Self::handle_connection(
+                            stream,
+                            addr,
+                            sessions,
+                            token,
+                            session_permit,
+                            handshake_timeout,
+                        )
+                        .await
                         {
                             warn!("Connection error for {}: {}", addr, e);
                         }
@@ -173,105 +191,102 @@ impl TunnelServer {
         sessions: SessionStoreBackend,
         expected_token: String,
         _session_permit: SessionPermit,
+        handshake_timeout: Duration,
     ) -> Result<()> {
         let mut framed = Framed::new(stream, TunnelCodec::new());
 
         // 1. Handshake
-        if let Some(result) = framed.next().await {
-            let frame = result?;
-            match frame {
-                Frame::Handshake(handshake) => {
-                    let auth = match authenticate_handshake(*handshake, &expected_token, addr) {
-                        Ok(auth) => auth,
-                        Err(status) => {
-                            framed
-                                .send(Frame::HandshakeAck {
-                                    status,
-                                    session_id: Uuid::nil(),
-                                    version: 0,
-                                    server_capabilities: vec![],
-                                })
-                                .await?;
-                            return Ok(());
-                        }
-                    };
-
-                    let AuthenticatedHandshake {
-                        session_id,
-                        tunnel_id,
-                        negotiated_version,
-                        token,
-                        capabilities,
-                    } = auth;
-
-                    // Setup multiplexer with kanal channels
-                    let parts = framed.into_parts();
-                    let (read_half, write_half) = tokio::io::split(parts.io);
-
-                    // Reconstruct FramedRead for reading, preserving any buffered data.
-                    // Dropping read_buf causes decoder desync ("Frame too large: 2021161080").
-                    let mut stream = tokio_util::codec::FramedRead::new(read_half, parts.codec);
-                    if !parts.read_buf.is_empty() {
-                        stream.read_buffer_mut().extend_from_slice(&parts.read_buf);
-                    }
-
-                    let (frame_tx, frame_rx) = bounded_async::<PrioritizedFrame>(1024);
-
-                    // Spawn batched sender task for vectored I/O performance
-                    tokio::spawn(run_batched_sender(frame_rx, write_half, parts.codec));
-
-                    let (multiplexer, new_stream_rx) = Multiplexer::new(frame_tx, false);
-
-                    // Log unexpected streams from client (for now)
-                    tokio::spawn(async move {
-                        while let Ok(_stream) = new_stream_rx.recv().await {
-                            warn!("Client tried to open stream (not supported in MVP)");
-                        }
-                    });
-
-                    let session = Session::new(
-                        session_id,
-                        tunnel_id.clone(),
-                        addr,
-                        token,
-                        capabilities,
-                        Some(AnyMultiplexer::Tcp(multiplexer.clone())),
-                    );
-
-                    if let Err(e) = sessions.add(session) {
-                        warn!("Failed to register session: {}", e);
-                        multiplexer
-                            .send_frame(Frame::HandshakeAck {
-                                status: HandshakeStatus::TunnelIdTaken,
-                                session_id,
+        let frame = read_initial_handshake_frame(&mut framed, handshake_timeout, "server").await?;
+        match frame {
+            Frame::Handshake(handshake) => {
+                let auth = match authenticate_handshake(*handshake, &expected_token, addr) {
+                    Ok(auth) => auth,
+                    Err(status) => {
+                        framed
+                            .send(Frame::HandshakeAck {
+                                status,
+                                session_id: Uuid::nil(),
                                 version: 0,
                                 server_capabilities: vec![],
                             })
                             .await?;
-                        return Err(TunnelError::Protocol(format!(
-                            "Tunnel ID '{tunnel_id}' already in use"
-                        )));
+                        return Ok(());
                     }
+                };
 
-                    info!("Session established: {}", session_id);
+                let AuthenticatedHandshake {
+                    session_id,
+                    tunnel_id,
+                    negotiated_version,
+                    token,
+                    capabilities,
+                } = auth;
+
+                // Setup multiplexer with kanal channels
+                let parts = framed.into_parts();
+                let (read_half, write_half) = tokio::io::split(parts.io);
+
+                // Reconstruct FramedRead for reading, preserving any buffered data.
+                // Dropping read_buf causes decoder desync ("Frame too large: 2021161080").
+                let mut stream = tokio_util::codec::FramedRead::new(read_half, parts.codec);
+                if !parts.read_buf.is_empty() {
+                    stream.read_buffer_mut().extend_from_slice(&parts.read_buf);
+                }
+
+                let (frame_tx, frame_rx) = bounded_async::<PrioritizedFrame>(1024);
+
+                // Spawn batched sender task for vectored I/O performance
+                tokio::spawn(run_batched_sender(frame_rx, write_half, parts.codec));
+
+                let (multiplexer, new_stream_rx) = Multiplexer::new(frame_tx, false);
+
+                // Log unexpected streams from client (for now)
+                tokio::spawn(async move {
+                    while let Ok(_stream) = new_stream_rx.recv().await {
+                        warn!("Client tried to open stream (not supported in MVP)");
+                    }
+                });
+
+                let session = Session::new(
+                    session_id,
+                    tunnel_id.clone(),
+                    addr,
+                    token,
+                    capabilities,
+                    Some(AnyMultiplexer::Tcp(multiplexer.clone())),
+                );
+
+                if let Err(e) = sessions.add(session) {
+                    warn!("Failed to register session: {}", e);
                     multiplexer
                         .send_frame(Frame::HandshakeAck {
-                            status: HandshakeStatus::Success,
+                            status: HandshakeStatus::TunnelIdTaken,
                             session_id,
-                            version: negotiated_version,
-                            server_capabilities: vec!["basic".to_string()],
+                            version: 0,
+                            server_capabilities: vec![],
                         })
                         .await?;
+                    return Err(TunnelError::Protocol(format!(
+                        "Tunnel ID '{tunnel_id}' already in use"
+                    )));
+                }
 
-                    // Enter message loop
-                    Self::process_messages(stream, session_id, sessions, multiplexer).await?;
-                }
-                _ => {
-                    return Err(TunnelError::Protocol("Expected handshake".into()));
-                }
+                info!("Session established: {}", session_id);
+                multiplexer
+                    .send_frame(Frame::HandshakeAck {
+                        status: HandshakeStatus::Success,
+                        session_id,
+                        version: negotiated_version,
+                        server_capabilities: vec!["basic".to_string()],
+                    })
+                    .await?;
+
+                // Enter message loop
+                Self::process_messages(stream, session_id, sessions, multiplexer).await?;
             }
-        } else {
-            return Err(TunnelError::Connection("Connection closed".into()));
+            _ => {
+                return Err(TunnelError::Protocol("Expected handshake".into()));
+            }
         }
 
         Ok(())
@@ -332,6 +347,27 @@ impl TunnelServer {
     }
 }
 
+async fn read_initial_handshake_frame<S>(
+    framed: &mut S,
+    handshake_timeout: Duration,
+    context: &str,
+) -> Result<Frame>
+where
+    S: Stream<Item = std::io::Result<Frame>> + Unpin,
+{
+    let result = timeout(handshake_timeout, framed.next())
+        .await
+        .map_err(|_| {
+            TunnelError::Timeout(format!(
+                "{context} handshake timed out after {handshake_timeout:?}"
+            ))
+        })?;
+
+    result
+        .ok_or_else(|| TunnelError::Connection(format!("{context} handshake stream closed")))?
+        .map_err(TunnelError::Io)
+}
+
 #[cfg(feature = "quic")]
 impl TunnelServer {
     /// Run the QUIC transport server on the given UDP address.
@@ -353,6 +389,7 @@ impl TunnelServer {
 
         let sessions = self.sessions.clone();
         let timeout = self.session_timeout;
+        let handshake_timeout = self.handshake_timeout;
 
         // Spawn session cleanup task
         let cleanup_sessions = sessions.clone();
@@ -388,6 +425,7 @@ impl TunnelServer {
                             sessions,
                             token,
                             session_permit,
+                            handshake_timeout,
                         )
                         .await
                         {
@@ -413,12 +451,24 @@ impl TunnelServer {
         sessions: SessionStoreBackend,
         expected_token: String,
         _session_permit: SessionPermit,
+        handshake_timeout: Duration,
     ) -> Result<()> {
         // Accept the control stream (first bidi stream opened by client)
-        let (ctrl_send, ctrl_recv) = connection
-            .accept_bi()
-            .await
-            .map_err(|e| TunnelError::Connection(format!("QUIC control stream accept: {e}")))?;
+        let (ctrl_send, ctrl_recv) = match timeout(handshake_timeout, connection.accept_bi()).await
+        {
+            Ok(Ok(streams)) => streams,
+            Ok(Err(e)) => {
+                return Err(TunnelError::Connection(format!(
+                    "QUIC control stream accept: {e}"
+                )));
+            }
+            Err(_) => {
+                connection.close(quinn::VarInt::from_u32(0), b"handshake timeout");
+                return Err(TunnelError::Timeout(format!(
+                    "QUIC control stream not opened within {handshake_timeout:?}"
+                )));
+            }
+        };
 
         let mut ctrl_framed_recv =
             tokio_util::codec::FramedRead::new(ctrl_recv, TunnelCodec::new());
@@ -426,11 +476,20 @@ impl TunnelServer {
             tokio_util::codec::FramedWrite::new(ctrl_send, TunnelCodec::new());
 
         // 1. Handshake on control stream
-        let frame = ctrl_framed_recv
-            .next()
-            .await
-            .ok_or_else(|| TunnelError::Connection("QUIC control stream closed".into()))?
-            .map_err(TunnelError::Io)?;
+        let frame = match read_initial_handshake_frame(
+            &mut ctrl_framed_recv,
+            handshake_timeout,
+            "QUIC server",
+        )
+        .await
+        {
+            Ok(frame) => frame,
+            Err(err @ TunnelError::Timeout(_)) => {
+                connection.close(quinn::VarInt::from_u32(0), b"handshake timeout");
+                return Err(err);
+            }
+            Err(err) => return Err(err),
+        };
 
         let (session_id, tunnel_id, multiplexer) = match frame {
             Frame::Handshake(handshake) => {
@@ -679,5 +738,31 @@ mod tests {
     fn test_version_negotiation_failure() {
         // Client requires 3+, Server only has 1
         assert!(negotiate_version(3, 5).is_err());
+    }
+
+    #[tokio::test]
+    async fn handshake_timeout_releases_session_permit_for_silent_peer() {
+        let (server_side, _client_side) = tokio::io::duplex(1024);
+        let limits = ServerResourceLimits::new(1, 10, 100);
+        let permit = limits.try_acquire_session().unwrap();
+        assert_eq!(limits.available_sessions(), 0);
+
+        let stream: BoxedStream = Box::pin(server_side);
+        let err = TunnelServer::handle_connection(
+            stream,
+            "127.0.0.1:0".parse().unwrap(),
+            SessionStoreBackend::default(),
+            "token".to_string(),
+            permit,
+            Duration::from_millis(1),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(matches!(
+            err,
+            TunnelError::Timeout(msg) if msg.contains("server handshake timed out")
+        ));
+        assert_eq!(limits.available_sessions(), 1);
     }
 }

--- a/ferrotunnel-core/src/tunnel/server.rs
+++ b/ferrotunnel-core/src/tunnel/server.rs
@@ -3,17 +3,18 @@ use crate::resource_limits::{ServerResourceLimits, SessionPermit};
 use crate::stream::{AnyMultiplexer, Multiplexer, PrioritizedFrame};
 use crate::transport::batched_sender::run_batched_sender;
 use crate::transport::{self, BoxedStream, TransportConfig};
-use crate::tunnel::common::clamp_u128_to_u64;
+use crate::tunnel::common::{clamp_u128_to_u64, read_initial_handshake_frame};
 use crate::tunnel::session::{Session, SessionStoreBackend, ShardedSessionStore};
 use ferrotunnel_common::{Result, TunnelError};
 use ferrotunnel_protocol::codec::TunnelCodec;
 use ferrotunnel_protocol::constants::{MAX_PROTOCOL_VERSION, MIN_PROTOCOL_VERSION};
 use ferrotunnel_protocol::frame::{Frame, HandshakeFrame, HandshakeStatus};
-use futures::{SinkExt, Stream, StreamExt};
+use futures::{SinkExt, StreamExt};
 use kanal::bounded_async;
 use std::net::SocketAddr;
 use std::time::{Duration, Instant};
 use tokio::net::TcpListener;
+#[cfg(feature = "quic")]
 use tokio::time::timeout;
 use tokio_util::codec::Framed;
 use tracing::{error, info, warn};
@@ -345,27 +346,6 @@ impl TunnelServer {
         sessions.remove(&session_id);
         Ok(())
     }
-}
-
-async fn read_initial_handshake_frame<S>(
-    framed: &mut S,
-    handshake_timeout: Duration,
-    context: &str,
-) -> Result<Frame>
-where
-    S: Stream<Item = std::io::Result<Frame>> + Unpin,
-{
-    let result = timeout(handshake_timeout, framed.next())
-        .await
-        .map_err(|_| {
-            TunnelError::Timeout(format!(
-                "{context} handshake timed out after {handshake_timeout:?}"
-            ))
-        })?;
-
-    result
-        .ok_or_else(|| TunnelError::Connection(format!("{context} handshake stream closed")))?
-        .map_err(TunnelError::Io)
 }
 
 #[cfg(feature = "quic")]

--- a/ferrotunnel-http/Cargo.toml
+++ b/ferrotunnel-http/Cargo.toml
@@ -12,10 +12,10 @@ categories = ["network-programming", "web-programming"]
 description = "HTTP ingress and proxy implementation for FerroTunnel"
 
 [dependencies]
-ferrotunnel-core = { version = "1.0.8", path = "../ferrotunnel-core" }
-ferrotunnel-protocol = { version = "1.0.8", path = "../ferrotunnel-protocol" }
-ferrotunnel-plugin = { version = "1.0.8", path = "../ferrotunnel-plugin" }
-ferrotunnel-common = { version = "1.0.8", path = "../ferrotunnel-common" }
+ferrotunnel-core = { version = "1.1.0", path = "../ferrotunnel-core" }
+ferrotunnel-protocol = { version = "1.1.0", path = "../ferrotunnel-protocol" }
+ferrotunnel-plugin = { version = "1.1.0", path = "../ferrotunnel-plugin" }
+ferrotunnel-common = { version = "1.1.0", path = "../ferrotunnel-common" }
 tokio = { workspace = true }
 hyper = { version = "1", features = ["full", "http2"] }
 http-body-util = "0.1"
@@ -27,7 +27,7 @@ futures = "0.3"
 tower = { version = "0.5", features = ["full"] }
 tower-service = "0.3"
 thiserror = { workspace = true }
-ferrotunnel-observability = { version = "1.0.8", path = "../ferrotunnel-observability", optional = true }
+ferrotunnel-observability = { version = "1.1.0", path = "../ferrotunnel-observability", optional = true }
 h3 = { workspace = true, optional = true }
 h3-quinn = { workspace = true, optional = true }
 quinn = { workspace = true, optional = true }

--- a/ferrotunnel-observability/Cargo.toml
+++ b/ferrotunnel-observability/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["network-programming"]
 include = ["src/**", "Cargo.toml", "README.md"]
 
 [dependencies]
-ferrotunnel-common = { version = "1.0.8", path = "../ferrotunnel-common" }
+ferrotunnel-common = { version = "1.1.0", path = "../ferrotunnel-common" }
 anyhow = { workspace = true }
 
 # Metrics

--- a/ferrotunnel-observability/Cargo.toml
+++ b/ferrotunnel-observability/Cargo.toml
@@ -56,6 +56,9 @@ reqwest = { version = "0.13.1", features = ["json"] }
 rust-embed = { version = "8.5", optional = true }
 mime_guess = { version = "2.0", optional = true }
 
+# Constant-time token comparison for dashboard auth
+subtle = { version = "2", optional = true }
+
 # Using custom lints to allow unwrap in metrics initialization
 [lints.rust]
 unsafe_code = "forbid"
@@ -98,4 +101,5 @@ dashboard = [
     "dep:tokio-stream",
     "dep:rust-embed",
     "dep:mime_guess",
+    "dep:subtle",
 ]

--- a/ferrotunnel-observability/README.md
+++ b/ferrotunnel-observability/README.md
@@ -12,7 +12,7 @@ Observability infrastructure for FerroTunnel, providing metrics, distributed tra
 
 ## Dashboard
 
-The built-in dashboard provides a web UI for monitoring and debugging tunnel traffic.
+The built-in dashboard provides a web UI for monitoring and debugging tunnel traffic. It binds to loopback by default; exposed binds should be paired with a dashboard auth token.
 
 ### Features
 
@@ -42,13 +42,16 @@ async fn main() {
     let broadcaster = Arc::new(EventBroadcaster::new(100));
 
     // Create the dashboard router
-    let app = create_router(state.clone(), broadcaster.clone());
+    let app = create_router(state.clone(), broadcaster.clone(), Some("dashboard-token".to_string()));
 
     // Serve the dashboard
     let listener = tokio::net::TcpListener::bind("127.0.0.1:4040").await.unwrap();
     axum::serve(listener, app).await.unwrap();
 }
 ```
+
+
+By default, the CLI dashboard binds to `127.0.0.1:4040`. Binding to a non-loopback address requires both `--dashboard-bind` and `--dashboard-allow-non-loopback`. The CLI always protects dashboard API routes: set `--dashboard-auth-token` or `FERROTUNNEL_DASHBOARD_AUTH_TOKEN` to choose the token, or use the generated token URL printed at startup. The embedded UI stores `?token=` in session storage and prompts again if the API returns `401`.
 
 ### API Endpoints
 
@@ -109,10 +112,12 @@ Observability is **disabled by default** for maximum performance. Enable it with
 
 ```bash
 # Server with observability enabled
-ferrotunnel server --token secret --observability
+export FERROTUNNEL_TOKEN=secret
+ferrotunnel server --observability
 
 # Client with observability enabled
-ferrotunnel client --server localhost:7835 --token secret --observability
+export FERROTUNNEL_TOKEN=secret
+ferrotunnel client --server localhost:7835 --observability
 ```
 
 Or via environment variable:

--- a/ferrotunnel-observability/src/dashboard/mod.rs
+++ b/ferrotunnel-observability/src/dashboard/mod.rs
@@ -42,6 +42,7 @@ use axum::{
     routing::{get, post},
     Router,
 };
+use subtle::ConstantTimeEq;
 use tower_http::{compression::CompressionLayer, trace::TraceLayer};
 
 const DASHBOARD_AUTH_HEADER: &str = "x-dashboard-token";
@@ -126,7 +127,17 @@ pub fn create_router(
         .nest("/api/v1", api_routes)
         .fallback(static_handler)
         .layer(CompressionLayer::new())
-        .layer(TraceLayer::new_for_http())
+        // Record only method + path in the request span. The dashboard auth
+        // token can be supplied as a `?token=` query parameter (EventSource
+        // cannot send headers), so the query string must never reach tracing
+        // spans, which may be exported to external log sinks.
+        .layer(TraceLayer::new_for_http().make_span_with(|request: &Request<Body>| {
+            tracing::info_span!(
+                "http_request",
+                method = %request.method(),
+                path = request.uri().path(),
+            )
+        }))
 }
 
 async fn dashboard_auth_middleware(
@@ -237,17 +248,20 @@ const fn hex_value(byte: u8) -> Option<u8> {
     }
 }
 
+/// Constant-time token comparison backed by the audited `subtle` crate.
+///
+/// Runs over `max(left.len(), right.len())` bytes and folds the length check
+/// into the result, so it neither short-circuits on a length mismatch nor
+/// relies on the optimizer preserving a hand-rolled data-dependent loop.
 fn constant_time_eq(left: &[u8], right: &[u8]) -> bool {
     let max_len = left.len().max(right.len());
-    let mut diff = left.len() ^ right.len();
-
+    let mut matches = left.len().ct_eq(&right.len());
     for index in 0..max_len {
         let left_byte = left.get(index).copied().unwrap_or(0);
         let right_byte = right.get(index).copied().unwrap_or(0);
-        diff |= usize::from(left_byte ^ right_byte);
+        matches &= left_byte.ct_eq(&right_byte);
     }
-
-    diff == 0
+    matches.into()
 }
 
 /// Configuration for the dashboard server.
@@ -322,5 +336,45 @@ mod tests {
             .unwrap();
 
         assert_eq!(response.status().as_u16(), StatusCode::OK.as_u16());
+    }
+
+    #[tokio::test]
+    async fn api_auth_accepts_query_token() {
+        let base_url = spawn_dashboard(Some("secret-token".to_string())).await;
+        let response = reqwest::get(format!("{base_url}/api/v1/health?token=secret-token"))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status().as_u16(), StatusCode::OK.as_u16());
+    }
+
+    #[tokio::test]
+    async fn api_auth_accepts_cookie_token() {
+        let base_url = spawn_dashboard(Some("secret-token".to_string())).await;
+        let client = reqwest::Client::new();
+        let response = client
+            .get(format!("{base_url}/api/v1/health"))
+            .header(
+                header::COOKIE,
+                format!("{DASHBOARD_AUTH_COOKIE}=secret-token"),
+            )
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(response.status().as_u16(), StatusCode::OK.as_u16());
+    }
+
+    #[tokio::test]
+    async fn api_auth_rejects_wrong_query_token() {
+        let base_url = spawn_dashboard(Some("secret-token".to_string())).await;
+        let response = reqwest::get(format!("{base_url}/api/v1/health?token=wrong-token"))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            response.status().as_u16(),
+            StatusCode::UNAUTHORIZED.as_u16()
+        );
     }
 }

--- a/ferrotunnel-observability/src/dashboard/mod.rs
+++ b/ferrotunnel-observability/src/dashboard/mod.rs
@@ -14,10 +14,10 @@
 //! let broadcaster = Arc::new(EventBroadcaster::new(100));
 //!
 //! // Create the router
-//! let app = create_router(state, broadcaster);
+//! let app = create_router(state, broadcaster, None);
 //!
 //! // Run the server
-//! let listener = tokio::net::TcpListener::bind("0.0.0.0:4040").await?;
+//! let listener = tokio::net::TcpListener::bind("127.0.0.1:4040").await?;
 //! axum::serve(listener, app).await?;
 //! ```
 
@@ -34,16 +34,23 @@ pub use models::{
 use std::sync::Arc;
 
 use axum::{
-    http::StatusCode,
-    response::IntoResponse,
+    body::Body,
+    extract::State,
+    http::{header, HeaderMap, Request, StatusCode},
+    middleware::{self, Next},
+    response::{IntoResponse, Response},
     routing::{get, post},
     Router,
 };
-use tower_http::{
-    compression::CompressionLayer,
-    cors::{Any, CorsLayer},
-    trace::TraceLayer,
-};
+use tower_http::{compression::CompressionLayer, trace::TraceLayer};
+
+const DASHBOARD_AUTH_HEADER: &str = "x-dashboard-token";
+const DASHBOARD_AUTH_COOKIE: &str = "ferrotunnel_dashboard_token";
+
+#[derive(Clone)]
+struct DashboardAuth {
+    token: Arc<str>,
+}
 
 /// Creates the dashboard API router with all endpoints.
 ///
@@ -51,6 +58,7 @@ use tower_http::{
 ///
 /// * `state` - Shared dashboard state for tunnel and request data.
 /// * `broadcaster` - Event broadcaster for SSE streaming.
+/// * `auth_token` - Optional token required for all `/api/v1/*` endpoints.
 ///
 /// # Endpoints
 ///
@@ -74,18 +82,18 @@ async fn static_handler(uri: axum::http::Uri) -> impl IntoResponse {
     match Assets::get(path) {
         Some(content) => {
             let mime = mime_guess::from_path(path).first_or_octet_stream();
-            (
-                [(axum::http::header::CONTENT_TYPE, mime.as_ref())],
-                content.data,
-            )
-                .into_response()
+            ([(header::CONTENT_TYPE, mime.as_ref())], content.data).into_response()
         }
         None => (StatusCode::NOT_FOUND, "404 Not Found").into_response(),
     }
 }
 
-pub fn create_router(state: SharedDashboardState, broadcaster: Arc<EventBroadcaster>) -> Router {
-    let api_routes = Router::new()
+pub fn create_router(
+    state: SharedDashboardState,
+    broadcaster: Arc<EventBroadcaster>,
+    auth_token: Option<String>,
+) -> Router {
+    let data_routes = Router::new()
         .route("/health", get(handlers::health_handler))
         .route("/tunnels", get(handlers::list_tunnels_handler))
         .route("/tunnels/{id}", get(handlers::get_tunnel_handler))
@@ -96,21 +104,150 @@ pub fn create_router(state: SharedDashboardState, broadcaster: Arc<EventBroadcas
             post(handlers::replay_request_handler),
         )
         .route("/metrics", get(handlers::metrics_handler))
-        .with_state(state)
+        .with_state(state);
+
+    let event_routes = Router::new()
         .route("/events", get(events::events_handler))
         .with_state(broadcaster);
+
+    let api_routes = match auth_token {
+        Some(token) => data_routes
+            .merge(event_routes)
+            .layer(middleware::from_fn_with_state(
+                DashboardAuth {
+                    token: Arc::from(token),
+                },
+                dashboard_auth_middleware,
+            )),
+        None => data_routes.merge(event_routes),
+    };
 
     Router::new()
         .nest("/api/v1", api_routes)
         .fallback(static_handler)
         .layer(CompressionLayer::new())
         .layer(TraceLayer::new_for_http())
-        .layer(
-            CorsLayer::new()
-                .allow_origin(Any)
-                .allow_methods(Any)
-                .allow_headers(Any),
-        )
+}
+
+async fn dashboard_auth_middleware(
+    State(auth): State<DashboardAuth>,
+    req: Request<Body>,
+    next: Next,
+) -> Response {
+    let provided = request_auth_token(req.headers(), req.uri().query());
+    if let Some(provided) = provided {
+        if constant_time_eq(provided.as_bytes(), auth.token.as_bytes()) {
+            return next.run(req).await;
+        }
+    }
+
+    (
+        StatusCode::UNAUTHORIZED,
+        [(header::WWW_AUTHENTICATE, "Bearer")],
+        "Unauthorized",
+    )
+        .into_response()
+}
+
+fn request_auth_token(headers: &HeaderMap, query: Option<&str>) -> Option<String> {
+    bearer_token(headers)
+        .or_else(|| header_token(headers))
+        .or_else(|| cookie_token(headers))
+        .or_else(|| query_token(query))
+}
+
+fn bearer_token(headers: &HeaderMap) -> Option<String> {
+    let value = headers.get(header::AUTHORIZATION)?.to_str().ok()?;
+    let (scheme, token) = value.split_once(' ')?;
+    if scheme.eq_ignore_ascii_case("bearer") {
+        Some(token.to_string())
+    } else {
+        None
+    }
+}
+
+fn header_token(headers: &HeaderMap) -> Option<String> {
+    headers
+        .get(DASHBOARD_AUTH_HEADER)
+        .and_then(|value| value.to_str().ok())
+        .map(ToString::to_string)
+}
+
+fn cookie_token(headers: &HeaderMap) -> Option<String> {
+    let value = headers.get(header::COOKIE)?.to_str().ok()?;
+    value.split(';').find_map(|part| {
+        let (name, token) = part.trim().split_once('=')?;
+        if name == DASHBOARD_AUTH_COOKIE {
+            Some(percent_decode(token, false))
+        } else {
+            None
+        }
+    })
+}
+
+fn query_token(query: Option<&str>) -> Option<String> {
+    query?.split('&').find_map(|part| {
+        let (name, token) = part.split_once('=').unwrap_or((part, ""));
+        if percent_decode(name, true) == "token" {
+            Some(percent_decode(token, true))
+        } else {
+            None
+        }
+    })
+}
+
+fn percent_decode(value: &str, plus_as_space: bool) -> String {
+    let bytes = value.as_bytes();
+    let mut decoded = Vec::with_capacity(bytes.len());
+    let mut index = 0;
+
+    while index < bytes.len() {
+        match bytes[index] {
+            b'%' if index + 2 < bytes.len() => {
+                if let (Some(high), Some(low)) =
+                    (hex_value(bytes[index + 1]), hex_value(bytes[index + 2]))
+                {
+                    decoded.push((high << 4) | low);
+                    index += 3;
+                    continue;
+                }
+                decoded.push(bytes[index]);
+                index += 1;
+            }
+            b'+' if plus_as_space => {
+                decoded.push(b' ');
+                index += 1;
+            }
+            byte => {
+                decoded.push(byte);
+                index += 1;
+            }
+        }
+    }
+
+    String::from_utf8_lossy(&decoded).into_owned()
+}
+
+const fn hex_value(byte: u8) -> Option<u8> {
+    match byte {
+        b'0'..=b'9' => Some(byte - b'0'),
+        b'a'..=b'f' => Some(byte - b'a' + 10),
+        b'A'..=b'F' => Some(byte - b'A' + 10),
+        _ => None,
+    }
+}
+
+fn constant_time_eq(left: &[u8], right: &[u8]) -> bool {
+    let max_len = left.len().max(right.len());
+    let mut diff = left.len() ^ right.len();
+
+    for index in 0..max_len {
+        let left_byte = left.get(index).copied().unwrap_or(0);
+        let right_byte = right.get(index).copied().unwrap_or(0);
+        diff |= usize::from(left_byte ^ right_byte);
+    }
+
+    diff == 0
 }
 
 /// Configuration for the dashboard server.
@@ -131,5 +268,59 @@ impl Default for DashboardConfig {
             max_requests: 1000,
             auth_token: None,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::sync::RwLock;
+
+    async fn spawn_dashboard(auth_token: Option<String>) -> String {
+        let state = Arc::new(RwLock::new(DashboardState::new(10)));
+        let broadcaster = Arc::new(EventBroadcaster::new(10));
+        let app = create_router(state, broadcaster, auth_token);
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        format!("http://{addr}")
+    }
+
+    #[test]
+    fn constant_time_compare_matches_equal_tokens() {
+        assert!(constant_time_eq(b"secret-token", b"secret-token"));
+        assert!(!constant_time_eq(b"secret-token", b"secret-tokem"));
+        assert!(!constant_time_eq(b"secret-token", b"secret-token-longer"));
+    }
+
+    #[tokio::test]
+    async fn api_auth_rejects_missing_token() {
+        let base_url = spawn_dashboard(Some("secret-token".to_string())).await;
+        let response = reqwest::get(format!("{base_url}/api/v1/health"))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            response.status().as_u16(),
+            StatusCode::UNAUTHORIZED.as_u16()
+        );
+    }
+
+    #[tokio::test]
+    async fn api_auth_accepts_bearer_token() {
+        let base_url = spawn_dashboard(Some("secret-token".to_string())).await;
+        let client = reqwest::Client::new();
+        let response = client
+            .get(format!("{base_url}/api/v1/health"))
+            .bearer_auth("secret-token")
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(response.status().as_u16(), StatusCode::OK.as_u16());
     }
 }

--- a/ferrotunnel-observability/src/dashboard/static/app.js
+++ b/ferrotunnel-observability/src/dashboard/static/app.js
@@ -28,6 +28,95 @@ const fmtTime = (iso) => new Date(iso).toLocaleTimeString();
 const fmtDuration = (ms) => `${ms}ms`;
 const fmtSize = (bytes) => bytes < 1024 ? `${bytes}B` : `${(bytes / 1024).toFixed(1)}KB`;
 
+const AUTH_TOKEN_KEY = 'ferrotunnel.dashboard.authToken';
+const AUTH_COOKIE_NAME = 'ferrotunnel_dashboard_token';
+
+const HTML_ESCAPE_MAP = {
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;'
+};
+
+function escapeHtml(value) {
+    return String(value ?? '').replace(/[&<>"']/g, char => HTML_ESCAPE_MAP[char]);
+}
+
+function classToken(value) {
+    return String(value ?? 'unknown').replace(/[^a-zA-Z0-9_-]/g, '').toLowerCase() || 'unknown';
+}
+
+function statusFamily(status) {
+    const family = Math.floor(Number(status) / 100);
+    return family >= 1 && family <= 5 ? `${family}xx` : 'unknown';
+}
+
+function safeHttpUrl(value) {
+    if (!value || value === 'N/A') return null;
+    try {
+        const url = new URL(String(value));
+        return url.protocol === 'http:' || url.protocol === 'https:' ? url.href : null;
+    } catch {
+        return null;
+    }
+}
+
+function setDashboardAuthToken(token) {
+    sessionStorage.setItem(AUTH_TOKEN_KEY, token);
+    document.cookie = `${AUTH_COOKIE_NAME}=${encodeURIComponent(token)}; Path=/; SameSite=Strict`;
+}
+
+function getDashboardAuthToken() {
+    const urlToken = new URLSearchParams(window.location.search).get('token');
+    if (urlToken) {
+        setDashboardAuthToken(urlToken);
+        return urlToken;
+    }
+
+    return sessionStorage.getItem(AUTH_TOKEN_KEY) || '';
+}
+
+function authHeaders(existingHeaders) {
+    const headers = new Headers(existingHeaders || {});
+    const token = getDashboardAuthToken();
+    if (token) headers.set('Authorization', `Bearer ${token}`);
+    return headers;
+}
+
+async function dashboardFetch(url, init = {}) {
+    const request = () => fetch(url, { ...init, headers: authHeaders(init.headers) });
+    let response = await request();
+    if (response.status !== 401) return response;
+
+    const token = prompt('Dashboard auth token');
+    if (!token) return response;
+
+    setDashboardAuthToken(token);
+    response = await request();
+    return response;
+}
+
+async function dashboardJson(url, init = {}) {
+    const response = await dashboardFetch(url, init);
+    if (!response.ok) throw new Error(`Request failed with status ${response.status}`);
+    return response.json();
+}
+
+function apiEventSourceUrl() {
+    const token = getDashboardAuthToken();
+    return token ? `/api/v1/events?token=${encodeURIComponent(token)}` : '/api/v1/events';
+}
+
+function setMessage(containerId, message, color = '') {
+    const container = document.getElementById(containerId);
+    const div = document.createElement('div');
+    div.style.padding = '1rem';
+    if (color) div.style.color = color;
+    div.textContent = message;
+    container.replaceChildren(div);
+}
+
 // Init Chart
 let trafficChart;
 
@@ -127,69 +216,71 @@ function renderStats() {
 }
 
 function renderRequestRow(req) {
-    const tr = document.createElement('tr');
-    tr.dataset.id = req.id;
+    const tr = document.createElement("tr");
+    const method = String(req.method || "");
+    const status = Number(req.status) || 0;
+
+    tr.dataset.id = String(req.id || "");
     tr.innerHTML = `
-        <td><span class="badge-method method-${req.method}">${req.method}</span></td>
-        <td><div style="max-width:300px;overflow:hidden;text-overflow:ellipsis">${req.path}</div></td>
-        <td><span class="status-code status-${Math.floor(req.status / 100)}xx">${req.status}</span></td>
-        <td>${fmtSize(req.response_size || 0)}</td>
-        <td>${fmtDuration(req.duration_ms || 0)}</td>
-        <td style="color:var(--text-secondary)">${fmtTime(req.timestamp)}</td>
+        <td><span class="badge-method method-${classToken(method)}">${escapeHtml(method)}</span></td>
+        <td><div style="max-width:300px;overflow:hidden;text-overflow:ellipsis">${escapeHtml(req.path)}</div></td>
+        <td><span class="status-code status-${statusFamily(status)}">${escapeHtml(status)}</span></td>
+        <td>${escapeHtml(fmtSize(req.response_size || 0))}</td>
+        <td>${escapeHtml(fmtDuration(req.duration_ms || 0))}</td>
+        <td style="color:var(--text-secondary)">${escapeHtml(fmtTime(req.timestamp))}</td>
     `;
-    tr.addEventListener('click', () => openDetails(req));
+    tr.addEventListener("click", () => openDetails(req));
     return tr;
 }
-
 function renderRequestList() {
-    els.requestTableBody.innerHTML = '';
+    els.requestTableBody.replaceChildren();
     state.requests.forEach(req => {
         els.requestTableBody.appendChild(renderRequestRow(req));
     });
 }
-
-// Detail Panel
 async function openDetails(summaryReq) {
     state.selectedRequestId = summaryReq.id;
     els.detailsPanel.classList.add('open');
 
-    // Show loading state while fetching full details
-    document.getElementById('detail-method').textContent = summaryReq.method;
-    document.getElementById('detail-method').className = `method-badge method-${summaryReq.method}`;
+    const detailMethod = document.getElementById('detail-method');
+    detailMethod.textContent = summaryReq.method;
+    detailMethod.className = `method-badge method-${classToken(summaryReq.method)}`;
     document.getElementById('detail-path').textContent = summaryReq.path;
 
-    // Clear previous data
-    document.getElementById('detail-req-headers').innerHTML = '<div style="padding:1rem">Loading...</div>';
-    document.getElementById('detail-res-headers').innerHTML = '<div style="padding:1rem">Loading...</div>';
+    setMessage('detail-req-headers', 'Loading...');
+    setMessage('detail-res-headers', 'Loading...');
     document.getElementById('detail-req-body').textContent = 'Loading...';
     document.getElementById('detail-res-body').textContent = 'Loading...';
 
     try {
-        const res = await fetch(`/api/v1/requests/${summaryReq.id}`);
-        if (!res.ok) throw new Error('Failed to fetch details');
-        const req = await res.json();
+        const req = await dashboardJson(`/api/v1/requests/${summaryReq.id}`);
 
-        // Render Headers
         const renderHeaders = (headers, containerId) => {
             const container = document.getElementById(containerId);
+            container.replaceChildren();
             if (!headers || Object.keys(headers).length === 0) {
-                container.innerHTML = '<div style="color:var(--text-muted);padding:1rem">No headers captured</div>';
+                setMessage(containerId, 'No headers captured', 'var(--text-muted)');
                 return;
             }
-            container.innerHTML = Object.entries(headers).map(([k, v]) => `
-                <div><dt>${k}</dt><dd>${v}</dd></div>
-            `).join('');
+
+            Object.entries(headers).forEach(([key, value]) => {
+                const row = document.createElement('div');
+                const name = document.createElement('dt');
+                const headerValue = document.createElement('dd');
+                name.textContent = key;
+                headerValue.textContent = value;
+                row.append(name, headerValue);
+                container.appendChild(row);
+            });
         };
 
         renderHeaders(req.request_headers, 'detail-req-headers');
         renderHeaders(req.response_headers, 'detail-res-headers');
 
-        // Render Body
         const renderBody = (body, containerId) => {
             const container = document.getElementById(containerId);
-            if (!body) { container.innerHTML = '// No body content'; return; }
+            if (!body) { container.textContent = '// No body content'; return; }
             try {
-                // If body is already a string but potentially JSON
                 if (typeof body !== 'string') body = JSON.stringify(body, null, 2);
                 const json = JSON.parse(body);
                 container.textContent = JSON.stringify(json, null, 2);
@@ -203,28 +294,24 @@ async function openDetails(summaryReq) {
 
     } catch (e) {
         console.error("Error fetching details", e);
-        document.getElementById('detail-req-headers').innerHTML = '<div style="color:red;padding:1rem">Error loading details</div>';
+        setMessage('detail-req-headers', 'Error loading details', 'red');
     }
 
-    // Reset tabs
     document.querySelectorAll('.tab-link').forEach(t => t.classList.remove('active'));
     document.querySelectorAll('.tab-content').forEach(c => c.classList.remove('active'));
     document.querySelector('.tab-link[data-tab="req-headers"]').classList.add('active');
     document.getElementById('req-headers').classList.add('active');
 }
-
-// Data Fetching
 async function fetchInitialData() {
     try {
-        const [tunnelsRes, reqsRes, healthRes] = await Promise.all([
-            fetch('/api/v1/tunnels'),
-            fetch('/api/v1/requests'),
-            fetch('/api/v1/health')
+        const [tunnels, requests, health] = await Promise.all([
+            dashboardJson('/api/v1/tunnels'),
+            dashboardJson('/api/v1/requests'),
+            dashboardJson('/api/v1/health')
         ]);
 
-        state.tunnels = await tunnelsRes.json();
-        state.requests = await reqsRes.json();
-        const health = await healthRes.json();
+        state.tunnels = tunnels;
+        state.requests = requests;
 
         if (health && health.version) {
             const verEl = document.getElementById('setting-version');
@@ -237,12 +324,12 @@ async function fetchInitialData() {
         renderRequestList();
         renderTunnels();
         renderAllRequests();
+        return true;
     } catch (e) {
         console.error("Failed to fetch initial data", e);
+        return false;
     }
 }
-
-// Render Tunnels (New)
 function renderTunnels() {
     const container = document.getElementById('tunnels-list');
     if (!state.tunnels.length) {
@@ -258,7 +345,12 @@ function renderTunnels() {
 
     container.innerHTML = state.tunnels.map(t => {
         const statusStyle = getStatusStyle(t.status);
-        const hasPublicUrl = t.public_url && t.public_url !== 'N/A';
+        const publicUrlText = t.public_url && t.public_url !== 'N/A' ? String(t.public_url) : '';
+        const publicUrl = safeHttpUrl(publicUrlText);
+        const subdomain = escapeHtml(t.subdomain || 'Local Tunnel');
+        const localAddr = escapeHtml(t.local_addr);
+        const statusText = escapeHtml(String(t.status || 'unknown').toUpperCase());
+        const publicUrlDisplay = publicUrlText ? `${escapeHtml(publicUrlText)} <span style="margin:0 0.5rem; opacity:0.5">→</span>` : '';
         return `
         <div class="tunnel-item" style="display:flex; justify-content:space-between; align-items:center; padding:1.25rem; background:rgba(255,255,255,0.03); border:1px solid var(--border-color); border-radius:0.75rem; margin-bottom:1rem;">
             <div style="display:flex; align-items:center; gap:1rem;">
@@ -267,68 +359,56 @@ function renderTunnels() {
                 </div>
                 <div>
                     <div style="font-weight:600; font-size:1.05rem; margin-bottom:0.25rem; display:flex; align-items:center; gap:0.5rem;">
-                        ${t.subdomain || 'Local Tunnel'}
-                        ${hasPublicUrl ? `<a href="${t.public_url}" target="_blank" style="color:var(--text-secondary); text-decoration:none; display:flex; align-items:center" title="Open URL">
+                        ${subdomain}
+                        ${publicUrl ? `<a href="${escapeHtml(publicUrl)}" target="_blank" rel="noopener noreferrer" style="color:var(--text-secondary); text-decoration:none; display:flex; align-items:center" title="Open URL">
                             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path><polyline points="15 3 21 3 21 9"></polyline><line x1="10" y1="14" x2="21" y2="3"></line></svg>
                         </a>` : ''}
                     </div>
                     <div style="color:var(--text-secondary); font-family:var(--font-mono); font-size:0.85rem;">
-                        ${hasPublicUrl ? `${t.public_url} <span style="margin:0 0.5rem; opacity:0.5">→</span>` : ''} ${t.local_addr}
+                        ${publicUrlDisplay} ${localAddr}
                     </div>
                 </div>
             </div>
             <div style="text-align:right">
                 <span class="status-indicator" style="display:inline-flex; align-items:center; gap:0.4rem; background:${statusStyle.bg}; color:${statusStyle.color}; padding:0.4rem 0.75rem; border-radius:2rem; font-size:0.85rem; font-weight:500;">
                     <span style="width:6px; height:6px; border-radius:50%; background:currentColor"></span>
-                    ${t.status.toUpperCase()}
+                    ${statusText}
                 </span>
                 <div style="margin-top:0.5rem; font-size:0.8rem; color:var(--text-muted)">
-                    Created ${fmtTime(t.created_at)}
+                    Created ${escapeHtml(fmtTime(t.created_at))}
                 </div>
             </div>
         </div>
     `}).join('');
 }
-
-// Render All Requests (New)
 function renderAllRequests() {
     const container = document.querySelector('#view-requests .card > div');
-    // Using simple reuse of the logic but customized for view
-    const tableHtml = `
-    <div class="table-responsive">
-        <table class="data-table">
-            <thead>
-                <tr>
-                    <th>Method</th>
-                    <th>Path</th>
-                    <th>Status</th>
-                    <th>Size</th>
-                    <th>Duration</th>
-                    <th>Time</th>
-                </tr>
-            </thead>
-            <tbody>
-                ${state.requests.map(req => {
-        return `
-                    <tr onclick='openDetails(${JSON.stringify(req).replace(/'/g, "&apos;")})'>
-                        <td><span class="badge-method method-${req.method}">${req.method}</span></td>
-                        <td>${req.path}</td>
-                        <td><span class="status-code status-${Math.floor(req.status / 100)}xx">${req.status}</span></td>
-                        <td>${fmtSize(req.response_size || 0)}</td>
-                        <td>${fmtDuration(req.duration_ms || 0)}</td>
-                        <td style="color:var(--text-secondary)">${fmtTime(req.timestamp)}</td>
-                    </tr>
-                    `;
-    }).join('')}
-            </tbody>
-        </table>
-    </div>`;
-    container.innerHTML = tableHtml;
-}
+    const wrapper = document.createElement('div');
+    wrapper.className = 'table-responsive';
 
-// SSE Setup
+    const table = document.createElement('table');
+    table.className = 'data-table';
+
+    const thead = document.createElement('thead');
+    const headerRow = document.createElement('tr');
+    ['Method', 'Path', 'Status', 'Size', 'Duration', 'Time'].forEach(label => {
+        const th = document.createElement('th');
+        th.textContent = label;
+        headerRow.appendChild(th);
+    });
+    thead.appendChild(headerRow);
+
+    const tbody = document.createElement('tbody');
+    state.requests.forEach(req => {
+        tbody.appendChild(renderRequestRow(req));
+    });
+
+    table.append(thead, tbody);
+    wrapper.appendChild(table);
+    container.replaceChildren(wrapper);
+}
 function setupSSE() {
-    const evtSource = new EventSource("/api/v1/events");
+    const evtSource = new EventSource(apiEventSourceUrl());
 
     evtSource.onmessage = (event) => {
         try {
@@ -339,9 +419,8 @@ function setupSSE() {
                 state.requests.unshift(data.payload);
                 if (state.requests.length > state.maxRequests) state.requests.pop();
 
-                // Update metrics
                 state.metrics.requests++;
-                recordRequest(); // Track for live traffic chart
+                recordRequest();
                 if (data.payload.status >= 400) {
                     state.metrics.errorRate = (state.metrics.errorRate * 9 + 100) / 10;
                 } else {
@@ -349,7 +428,6 @@ function setupSSE() {
                 }
 
                 renderStats();
-                // Update both lists
                 els.requestTableBody.prepend(renderRequestRow(data.payload));
                 renderAllRequests();
 
@@ -360,8 +438,6 @@ function setupSSE() {
         } catch (e) { console.error("SSE Parse Error", e); }
     };
 }
-
-// Replay
 async function replayRequest() {
     if (!state.selectedRequestId) return;
     const req = state.requests.find(r => r.id === state.selectedRequestId);
@@ -373,11 +449,16 @@ async function replayRequest() {
         els.btnReplay.disabled = true;
         els.btnReplay.textContent = 'Replaying...';
 
-        const res = await fetch(`/api/v1/requests/${state.selectedRequestId}/replay`, {
+        const res = await dashboardFetch(`/api/v1/requests/${state.selectedRequestId}/replay`, {
             method: 'POST'
         });
 
-        const data = await res.json();
+        let data = {};
+        try {
+            data = await res.json();
+        } catch {
+            data = {};
+        }
 
         if (!res.ok) {
             throw new Error(data.error || 'Replay failed');
@@ -395,8 +476,9 @@ async function replayRequest() {
 // Event Listeners
 document.addEventListener('DOMContentLoaded', () => {
     initChart();
-    fetchInitialData();
-    setupSSE();
+    fetchInitialData().then((loaded) => {
+        if (loaded) setupSSE();
+    });
 
     // Sidebar Navigation
     document.querySelectorAll('.nav-links a').forEach(link => {

--- a/ferrotunnel-plugin/Cargo.toml
+++ b/ferrotunnel-plugin/Cargo.toml
@@ -19,6 +19,7 @@ tracing = { workspace = true }
 http = "1.1"
 tokio = { workspace = true }
 governor = "0.10"
+subtle = "2"
 
 [dev-dependencies]
 tracing-subscriber = "0.3"

--- a/ferrotunnel-plugin/src/builtin/auth.rs
+++ b/ferrotunnel-plugin/src/builtin/auth.rs
@@ -1,17 +1,30 @@
 use crate::traits::{Plugin, PluginAction, RequestContext};
 use async_trait::async_trait;
-use std::collections::HashSet;
+use subtle::{Choice, ConstantTimeEq};
 
 /// Token-based authentication plugin
 pub struct TokenAuthPlugin {
-    valid_tokens: HashSet<String>,
+    valid_tokens: Vec<String>,
     header_name: String,
+}
+
+fn constant_time_token_eq(expected: &[u8], presented: &[u8]) -> Choice {
+    let max_len = expected.len().max(presented.len());
+    let mut matches = expected.len().ct_eq(&presented.len());
+
+    for i in 0..max_len {
+        let expected_byte = expected.get(i).copied().unwrap_or(0);
+        let presented_byte = presented.get(i).copied().unwrap_or(0);
+        matches &= expected_byte.ct_eq(&presented_byte);
+    }
+
+    matches
 }
 
 impl TokenAuthPlugin {
     pub fn new(tokens: Vec<String>) -> Self {
         Self {
-            valid_tokens: tokens.into_iter().collect(),
+            valid_tokens: tokens,
             header_name: "X-Tunnel-Token".to_string(),
         }
     }
@@ -20,6 +33,16 @@ impl TokenAuthPlugin {
     pub fn with_header_name(mut self, name: String) -> Self {
         self.header_name = name;
         self
+    }
+
+    fn token_matches(&self, presented: &str) -> bool {
+        let presented = presented.as_bytes();
+        self.valid_tokens
+            .iter()
+            .fold(Choice::from(0), |matches, valid_token| {
+                matches | constant_time_token_eq(valid_token.as_bytes(), presented)
+            })
+            .into()
     }
 }
 
@@ -40,7 +63,7 @@ impl Plugin for TokenAuthPlugin {
             .and_then(|v| v.to_str().ok());
 
         match token {
-            Some(t) if self.valid_tokens.contains(t) => Ok(PluginAction::Continue),
+            Some(t) if self.token_matches(t) => Ok(PluginAction::Continue),
             _ => Ok(PluginAction::Reject {
                 status: 401,
                 reason: format!("Invalid or missing {}", self.header_name),
@@ -56,6 +79,31 @@ mod tests {
     #[tokio::test]
     async fn test_valid_token_allows_request() {
         let plugin = TokenAuthPlugin::new(vec!["secret123".to_string()]);
+
+        let mut req = http::Request::builder()
+            .header("X-Tunnel-Token", "secret123")
+            .uri("/")
+            .body(())
+            .unwrap();
+
+        let ctx = RequestContext {
+            tunnel_id: "test".into(),
+            session_id: "session".into(),
+            remote_addr: "127.0.0.1:1234".parse().unwrap(),
+            timestamp: std::time::SystemTime::now(),
+        };
+
+        let action = plugin.on_request(&mut req, &ctx).await.unwrap();
+        assert_eq!(action, PluginAction::Continue);
+    }
+
+    #[tokio::test]
+    async fn test_valid_token_allows_request_after_near_misses() {
+        let plugin = TokenAuthPlugin::new(vec![
+            "secret124".to_string(),
+            "secret1234".to_string(),
+            "secret123".to_string(),
+        ]);
 
         let mut req = http::Request::builder()
             .header("X-Tunnel-Token", "secret123")
@@ -97,5 +145,46 @@ mod tests {
             PluginAction::Reject { status, .. } => assert_eq!(status, 401),
             _ => panic!("Expected Reject"),
         }
+    }
+
+    #[tokio::test]
+    async fn test_missing_token_rejects_request() {
+        let plugin = TokenAuthPlugin::new(vec!["secret123".to_string()]);
+
+        let mut req = http::Request::builder().uri("/").body(()).unwrap();
+
+        let ctx = RequestContext {
+            tunnel_id: "test".into(),
+            session_id: "session".into(),
+            remote_addr: "127.0.0.1:1234".parse().unwrap(),
+            timestamp: std::time::SystemTime::now(),
+        };
+
+        let action = plugin.on_request(&mut req, &ctx).await.unwrap();
+
+        match action {
+            PluginAction::Reject { status, .. } => assert_eq!(status, 401),
+            _ => panic!("Expected Reject"),
+        }
+    }
+
+    #[test]
+    fn constant_time_token_eq_requires_full_byte_and_length_match() {
+        assert!(bool::from(constant_time_token_eq(
+            b"secret123",
+            b"secret123"
+        )));
+        assert!(!bool::from(constant_time_token_eq(
+            b"secret123",
+            b"secret124"
+        )));
+        assert!(!bool::from(constant_time_token_eq(
+            b"secret123",
+            b"secret1234"
+        )));
+        assert!(!bool::from(constant_time_token_eq(
+            b"secret1234",
+            b"secret123"
+        )));
     }
 }

--- a/ferrotunnel/Cargo.toml
+++ b/ferrotunnel/Cargo.toml
@@ -12,11 +12,11 @@ keywords = ["tunnel", "reverse-proxy", "networking", "async"]
 categories = ["network-programming", "asynchronous"]
 
 [dependencies]
-ferrotunnel-common = { version = "1.0.8", path = "../ferrotunnel-common" }
-ferrotunnel-protocol = { version = "1.0.8", path = "../ferrotunnel-protocol" }
-ferrotunnel-core = { version = "1.0.8", path = "../ferrotunnel-core" }
-ferrotunnel-http = { version = "1.0.8", path = "../ferrotunnel-http" }
-ferrotunnel-plugin = { version = "1.0.8", path = "../ferrotunnel-plugin" }
+ferrotunnel-common = { version = "1.1.0", path = "../ferrotunnel-common" }
+ferrotunnel-protocol = { version = "1.1.0", path = "../ferrotunnel-protocol" }
+ferrotunnel-core = { version = "1.1.0", path = "../ferrotunnel-core" }
+ferrotunnel-http = { version = "1.1.0", path = "../ferrotunnel-http" }
+ferrotunnel-plugin = { version = "1.1.0", path = "../ferrotunnel-plugin" }
 
 # Re-export commonly used dependencies
 tokio = { workspace = true }

--- a/tools/soak/Cargo.toml
+++ b/tools/soak/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 publish = false
 
 [dependencies]
-ferrotunnel = { version = "1.0.8", path = "../../ferrotunnel" }
+ferrotunnel = { version = "1.1.0", path = "../../ferrotunnel" }
 tokio = { workspace = true }
 clap = { version = "4", features = ["derive"] }
 anyhow = { workspace = true }


### PR DESCRIPTION
## Summary

- Prepare the FerroTunnel `1.1.0` security release.
- Harden token handling, dashboard exposure/authentication, dashboard rendering, tunnel handshakes, and TLS defaults.
- Bump Cargo package metadata to `1.1.0` and add the release changelog/plan.

## Validation

- `node --check ferrotunnel-observability/src/dashboard/static/app.js`
- `make check`
- `cargo test --workspace --all-features`
- `make audit`

## Fixed Issues

Closes #116
Closes #124
Closes #125
Closes #126
Closes #127
Closes #128
Closes #143