### PR TITLE
Release/1.2.0

### DIFF
--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -169,4 +169,7 @@ jobs:
           files: artifacts/**/*
           draft: true
           prerelease: true
-          generate_release_notes: false
+          # Keep the changelog excerpt (body_path) AND append GitHub's
+          # auto-generated "What's Changed" / "New Contributors" section so
+          # contributor @handles are credited on every release.
+          generate_release_notes: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-06-19
+
+Hardening release closing the v1.2.0 audit milestone.
+
+### Security
+
+- Bound and time-limit HTTP/1.1+HTTP/2 ingress bodies: `max_request_body_size` cap (oversized → 413) plus a per-frame response read timeout (stalled upstream → 504) ([#132](https://github.com/ferro-labs/ferrotunnel/issues/132)).
+- Enforce the previously dead per-session rate limiter: stream-open limits and byte-accurate data limits ([#119](https://github.com/ferro-labs/ferrotunnel/issues/119)).
+
+### Fixed
+
+- Isolate plugin hook panics so a panicking plugin yields a clean 500 instead of dropping the connection ([#138](https://github.com/ferro-labs/ferrotunnel/issues/138)).
+- Make metrics initialization idempotent and `/metrics` scraping panic-free ([#137](https://github.com/ferro-labs/ferrotunnel/issues/137)).
+- Survive transient `accept()` errors in HTTP/TCP ingress instead of terminating the accept loop ([#131](https://github.com/ferro-labs/ferrotunnel/issues/131)).
+- Back off on accept-loop errors (core TLS/QUIC and ingress) to avoid busy-spinning a core and flooding logs ([#130](https://github.com/ferro-labs/ferrotunnel/issues/130)).
+- Add send timeouts to the frame channel so teardown cannot hang under network partition ([#136](https://github.com/ferro-labs/ferrotunnel/issues/136)).
+- Track and abort the session-cleanup task on shutdown; guarantee one cleanup loop per server ([#135](https://github.com/ferro-labs/ferrotunnel/issues/135)).
+
 ## [1.1.0] - 2026-06-11
 
 ### Security
@@ -276,7 +294,11 @@ FerroTunnel v1.0.0 is the first stable release.
 | `ferrotunnel-observability` | Metrics, tracing, and dashboard |
 | `ferrotunnel-common` | Shared types and errors |
 
-[Unreleased]: https://github.com/ferro-labs/ferrotunnel/compare/v1.0.4...HEAD
+[Unreleased]: https://github.com/ferro-labs/ferrotunnel/compare/v1.2.0...HEAD
+[1.2.0]: https://github.com/ferro-labs/ferrotunnel/compare/v1.1.0...v1.2.0
+[1.1.0]: https://github.com/ferro-labs/ferrotunnel/compare/v1.0.8...v1.1.0
+[1.0.8]: https://github.com/ferro-labs/ferrotunnel/compare/v1.0.7...v1.0.8
+[1.0.7]: https://github.com/ferro-labs/ferrotunnel/compare/v1.0.6...v1.0.7
 [1.0.6]: https://github.com/ferro-labs/ferrotunnel/compare/v1.0.4...v1.0.6
 [1.0.4]: https://github.com/ferro-labs/ferrotunnel/compare/v1.0.3...v1.0.4
 [1.0.3]: https://github.com/ferro-labs/ferrotunnel/compare/v1.0.2...v1.0.3

--- a/ferrotunnel-cli/src/commands/server.rs
+++ b/ferrotunnel-cli/src/commands/server.rs
@@ -134,9 +134,33 @@ pub async fn run(args: ServerArgs) -> Result<()> {
         // Start metrics endpoint in background (only when metrics is enabled)
         let metrics_addr = args.metrics_bind;
         tokio::spawn(async move {
-            use axum::{routing::get, Router};
+            use axum::{
+                http::StatusCode,
+                response::{IntoResponse, Response},
+                routing::get,
+                Router,
+            };
+            async fn metrics_response() -> Response {
+                match gather_metrics() {
+                    Ok(metrics) => (
+                        StatusCode::OK,
+                        [("content-type", "text/plain; charset=utf-8")],
+                        metrics,
+                    )
+                        .into_response(),
+                    Err(error) => {
+                        tracing::error!(%error, "failed to gather metrics");
+                        (
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                            "failed to gather metrics\n",
+                        )
+                            .into_response()
+                    }
+                }
+            }
+
             let app = Router::new()
-                .route("/metrics", get(|| async { gather_metrics() }))
+                .route("/metrics", get(metrics_response))
                 .route("/health/ready", get(|| async { "OK" }));
             info!("Metrics server listening on http://{}", metrics_addr);
             match tokio::net::TcpListener::bind(metrics_addr).await {

--- a/ferrotunnel-core/Cargo.toml
+++ b/ferrotunnel-core/Cargo.toml
@@ -67,6 +67,7 @@ metrics = ["dep:ferrotunnel-observability"]
 
 [dev-dependencies]
 criterion = { workspace = true, features = ["async_tokio"] }
+tokio = { workspace = true, features = ["test-util"] }
 
 [[bench]]
 name = "transport"

--- a/ferrotunnel-core/Cargo.toml
+++ b/ferrotunnel-core/Cargo.toml
@@ -56,6 +56,10 @@ quinn = { workspace = true, optional = true }
 # Optional metrics (decode/encode latency, queue depth)
 ferrotunnel-observability = { version = "1.1.0", path = "../ferrotunnel-observability", optional = true }
 
+# File descriptor exhaustion (EMFILE/ENFILE) detection in accept-loop backoff
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 [features]
 default = []
 quic = ["dep:quinn"]

--- a/ferrotunnel-core/src/rate_limit.rs
+++ b/ferrotunnel-core/src/rate_limit.rs
@@ -31,6 +31,12 @@ impl Default for RateLimiterConfig {
     }
 }
 
+/// Compute an absolute burst capacity from a per-second `rate` and a `burst_factor`
+/// multiplier, saturating at [`NonZeroU32::MAX`] to avoid overflow.
+fn scaled_burst(rate: NonZeroU32, burst_factor: NonZeroU32) -> NonZeroU32 {
+    NonZeroU32::new(rate.get().saturating_mul(burst_factor.get())).unwrap_or(NonZeroU32::MAX)
+}
+
 /// Rate limiter for a single session
 #[derive(Clone)]
 pub struct SessionRateLimiter {
@@ -44,9 +50,14 @@ impl SessionRateLimiter {
     /// Create a new session rate limiter
     #[must_use]
     pub fn new(config: &RateLimiterConfig) -> Self {
-        let stream_quota =
-            Quota::per_second(config.streams_per_sec).allow_burst(config.burst_factor);
-        let bytes_quota = Quota::per_second(config.bytes_per_sec).allow_burst(config.burst_factor);
+        // `allow_burst` sets the ABSOLUTE burst capacity (in cells), not a multiplier.
+        // Because the byte limiter consumes one cell per byte via `check_n`, the burst
+        // capacity must scale with the rate (rate * burst_factor); otherwise a tiny
+        // burst would reject every real data frame.
+        let stream_quota = Quota::per_second(config.streams_per_sec)
+            .allow_burst(scaled_burst(config.streams_per_sec, config.burst_factor));
+        let bytes_quota = Quota::per_second(config.bytes_per_sec)
+            .allow_burst(scaled_burst(config.bytes_per_sec, config.burst_factor));
 
         Self {
             stream_limiter: Arc::new(RateLimiter::direct(stream_quota)),
@@ -62,12 +73,27 @@ impl SessionRateLimiter {
             .map_err(|_| RateLimitError::StreamRateLimited)
     }
 
-    /// Check if data can be sent (by byte count)
-    /// For simplicity, we check once per frame rather than exact bytes
-    pub fn check_data(&self, _bytes: usize) -> Result<(), RateLimitError> {
-        self.bytes_limiter
-            .check()
-            .map_err(|_| RateLimitError::BytesRateLimited)
+    /// Check if `bytes` of data can be sent, accounting for the actual payload size.
+    ///
+    /// Consumes `bytes` tokens from the byte-rate quota via governor's `check_n`
+    /// rather than a single token per frame. Empty payloads are always allowed.
+    ///
+    /// Fails closed: if the payload exceeds the quota's burst capacity (so it could
+    /// never conform), or the current rate is exceeded, this returns an error.
+    pub fn check_data(&self, bytes: usize) -> Result<(), RateLimitError> {
+        // Zero-length frames consume no quota.
+        let Some(n) = NonZeroU32::new(u32::try_from(bytes).unwrap_or(u32::MAX)) else {
+            return Ok(());
+        };
+
+        match self.bytes_limiter.check_n(n) {
+            // All requested cells fit within the current rate.
+            Ok(Ok(())) => Ok(()),
+            // Current rate exceeded; the batch may conform later.
+            Ok(Err(_)) => Err(RateLimitError::BytesRateLimited),
+            // Payload can never fit the burst capacity: fail closed.
+            Err(_insufficient_capacity) => Err(RateLimitError::BytesRateLimited),
+        }
     }
 
     /// Async version - waits until allowed
@@ -142,5 +168,47 @@ mod tests {
         }
         // Should be rate limited after burst
         assert!(limiter.check_stream_open().is_err());
+    }
+
+    #[test]
+    fn check_data_accounts_for_byte_count() {
+        // Capacity = bytes_per_sec * burst_factor = 1000 bytes.
+        let config = RateLimiterConfig {
+            streams_per_sec: NonZeroU32::new(100).unwrap(),
+            bytes_per_sec: NonZeroU32::new(1000).unwrap(),
+            burst_factor: NonZeroU32::new(1).unwrap(),
+        };
+        let limiter = SessionRateLimiter::new(&config);
+
+        // A single 1000-byte payload consumes the entire burst (proves bytes are
+        // counted, not a single token per frame).
+        assert!(limiter.check_data(1000).is_ok());
+        // The next equally-sized payload is rejected because the quota is exhausted.
+        assert!(limiter.check_data(1000).is_err());
+    }
+
+    #[test]
+    fn check_data_allows_empty_payload() {
+        let config = RateLimiterConfig {
+            streams_per_sec: NonZeroU32::new(1).unwrap(),
+            bytes_per_sec: NonZeroU32::new(1).unwrap(),
+            burst_factor: NonZeroU32::new(1).unwrap(),
+        };
+        let limiter = SessionRateLimiter::new(&config);
+        // Zero-length frames consume no quota and are always allowed.
+        assert!(limiter.check_data(0).is_ok());
+    }
+
+    #[test]
+    fn check_data_fails_closed_when_payload_exceeds_capacity() {
+        // Capacity = 10 bytes; a 100-byte payload can never conform.
+        let config = RateLimiterConfig {
+            streams_per_sec: NonZeroU32::new(100).unwrap(),
+            bytes_per_sec: NonZeroU32::new(10).unwrap(),
+            burst_factor: NonZeroU32::new(1).unwrap(),
+        };
+        let limiter = SessionRateLimiter::new(&config);
+        // InsufficientCapacity must fail closed.
+        assert!(limiter.check_data(100).is_err());
     }
 }

--- a/ferrotunnel-core/src/stream/multiplexer.rs
+++ b/ferrotunnel-core/src/stream/multiplexer.rs
@@ -12,14 +12,26 @@ use dashmap::mapref::entry::Entry;
 use dashmap::DashMap;
 use ferrotunnel_common::Result;
 use ferrotunnel_protocol::frame::{Frame, OpenStreamFrame, Protocol, StreamPriority};
-use kanal::{bounded_async, AsyncReceiver, AsyncSender, ReceiveError, SendError};
+use kanal::{bounded_async, AsyncReceiver, AsyncSender, ReceiveError};
 use std::io;
 use std::pin::Pin;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::{Arc, Mutex};
 use std::task::{Context, Poll};
+use std::time::Duration;
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+use tokio::time::timeout;
 use tracing::warn;
+
+/// Maximum time to wait when sending a frame to the wire channel (`frame_tx`)
+/// before treating the peer as unreachable and failing the send.
+///
+/// The `frame_tx` channel is drained by the batched sender. If that task exits
+/// (teardown) or stalls (network partition with a full channel), a plain
+/// `send().await` would block forever, preventing the read loop from observing
+/// EOF and hanging the session. Bounding every send with this deadline ensures
+/// teardown completes promptly. See issue #136.
+const FRAME_SEND_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Pool for reusing read buffers in `VirtualStream`
 pub type ReadBufferPool = ObjectPool<Vec<u8>>;
@@ -53,6 +65,26 @@ pub struct Multiplexer {
     frame_tx: AsyncSender<PrioritizedFrame>,
     new_stream_tx: AsyncSender<VirtualStream>,
     buffer_pool: ReadBufferPool,
+}
+
+/// Send a prioritized frame to the wire channel with a bounded deadline.
+///
+/// Returns a `BrokenPipe` error if the receiver has been dropped and a
+/// `TimedOut` error if the channel stays full past [`FRAME_SEND_TIMEOUT`].
+/// Either way the caller fails fast instead of hanging on teardown (#136).
+async fn send_prioritized_frame(
+    frame_tx: &AsyncSender<PrioritizedFrame>,
+    frame: PrioritizedFrame,
+) -> Result<()> {
+    match timeout(FRAME_SEND_TIMEOUT, frame_tx.send(frame)).await {
+        Ok(Ok(())) => Ok(()),
+        Ok(Err(e)) => Err(io::Error::new(io::ErrorKind::BrokenPipe, e.to_string()).into()),
+        Err(_) => Err(io::Error::new(
+            io::ErrorKind::TimedOut,
+            "timed out sending frame to wire channel",
+        )
+        .into()),
+    }
 }
 
 impl Multiplexer {
@@ -105,12 +137,12 @@ impl Multiplexer {
     }
 
     /// Send a frame directly to the wire (priority derived from frame type and stream).
+    ///
+    /// Bounded by [`FRAME_SEND_TIMEOUT`] so a full or torn-down `frame_tx`
+    /// channel fails fast instead of blocking the caller forever (issue #136).
     pub async fn send_frame(&self, frame: Frame) -> Result<()> {
         let priority = Self::priority_for_frame(&frame, &self.stream_priorities);
-        self.frame_tx
-            .send((priority, frame))
-            .await
-            .map_err(|e| io::Error::new(io::ErrorKind::BrokenPipe, e.to_string()).into())
+        send_prioritized_frame(&self.frame_tx, (priority, frame)).await
     }
 
     /// Process an incoming frame from the wire
@@ -220,8 +252,9 @@ impl Multiplexer {
         self.streams.insert(stream_id, tx);
 
         self.stream_priorities.insert(stream_id, priority);
-        self.frame_tx
-            .send((
+        send_prioritized_frame(
+            &self.frame_tx,
+            (
                 priority,
                 Frame::OpenStream(Box::new(OpenStreamFrame {
                     stream_id,
@@ -230,9 +263,9 @@ impl Multiplexer {
                     body_hint: None,
                     priority,
                 })),
-            ))
-            .await
-            .map_err(|e| io::Error::new(io::ErrorKind::BrokenPipe, e.to_string()))?;
+            ),
+        )
+        .await?;
 
         let read_buffer = self.buffer_pool.try_acquire().unwrap_or_default();
         Ok(VirtualStream::new(
@@ -257,9 +290,29 @@ type RecvFuture = Pin<
     Box<dyn std::future::Future<Output = std::result::Result<Result<Frame>, ReceiveError>> + Send>,
 >;
 
-/// Boxed future type for sending frames
-type SendFuture =
-    Pin<Box<dyn std::future::Future<Output = std::result::Result<(), SendError>> + Send>>;
+/// Boxed future type for sending frames.
+///
+/// Resolves to an `io::Result` because the send is bounded by
+/// [`FRAME_SEND_TIMEOUT`]: a full or closed `frame_tx` surfaces as an error
+/// rather than blocking the writer forever (issue #136).
+type SendFuture = Pin<Box<dyn std::future::Future<Output = io::Result<()>> + Send>>;
+
+/// Build the bounded send future stored in `pending_send`.
+///
+/// `poll_write` / `poll_shutdown` cannot `.await`, so the deadline is baked
+/// into the future itself; a timeout or closed channel resolves to an error.
+fn bounded_send_future(tx: AsyncSender<PrioritizedFrame>, frame: PrioritizedFrame) -> SendFuture {
+    Box::pin(async move {
+        match timeout(FRAME_SEND_TIMEOUT, tx.send(frame)).await {
+            Ok(Ok(())) => Ok(()),
+            Ok(Err(e)) => Err(io::Error::new(io::ErrorKind::BrokenPipe, e.to_string())),
+            Err(_) => Err(io::Error::new(
+                io::ErrorKind::TimedOut,
+                "timed out sending frame to wire channel",
+            )),
+        }
+    })
+}
 
 /// A virtual stream that implements `AsyncRead` + `AsyncWrite`
 ///
@@ -437,13 +490,7 @@ impl AsyncWrite for VirtualStream {
                     let bytes_written = self.pending_send_len;
                     self.pending_send = None;
                     self.pending_send_len = 0;
-                    if let Err(e) = result {
-                        return Poll::Ready(Err(io::Error::new(
-                            io::ErrorKind::BrokenPipe,
-                            e.to_string(),
-                        )));
-                    }
-                    return Poll::Ready(Ok(bytes_written));
+                    return Poll::Ready(result.map(|()| bytes_written));
                 }
                 Poll::Pending => return Poll::Pending,
             }
@@ -467,7 +514,7 @@ impl AsyncWrite for VirtualStream {
         let tx = self.tx.clone();
         // P3.1: Store length instead of frame, move frame into future
         self.pending_send_len = chunk_size;
-        self.pending_send = Some(Box::pin(async move { tx.send((priority, frame)).await }));
+        self.pending_send = Some(bounded_send_future(tx, (priority, frame)));
 
         // Poll the new future (we set it in the block above)
         let fut = match self.pending_send.as_mut() {
@@ -478,13 +525,7 @@ impl AsyncWrite for VirtualStream {
             Poll::Ready(result) => {
                 self.pending_send = None;
                 self.pending_send_len = 0;
-                match result {
-                    Ok(()) => Poll::Ready(Ok(chunk_size)),
-                    Err(e) => Poll::Ready(Err(io::Error::new(
-                        io::ErrorKind::BrokenPipe,
-                        e.to_string(),
-                    ))),
-                }
+                Poll::Ready(result.map(|()| chunk_size))
             }
             Poll::Pending => Poll::Pending,
         }
@@ -515,7 +556,7 @@ impl AsyncWrite for VirtualStream {
         let priority = self.priority;
 
         let tx = self.tx.clone();
-        self.pending_send = Some(Box::pin(async move { tx.send((priority, frame)).await }));
+        self.pending_send = Some(bounded_send_future(tx, (priority, frame)));
 
         let fut = match self.pending_send.as_mut() {
             Some(f) => f,
@@ -524,13 +565,7 @@ impl AsyncWrite for VirtualStream {
         match fut.as_mut().poll(cx) {
             Poll::Ready(result) => {
                 self.pending_send = None;
-                match result {
-                    Ok(()) => Poll::Ready(Ok(())),
-                    Err(e) => Poll::Ready(Err(io::Error::new(
-                        io::ErrorKind::BrokenPipe,
-                        e.to_string(),
-                    ))),
-                }
+                Poll::Ready(result)
             }
             Poll::Pending => Poll::Pending,
         }
@@ -562,5 +597,68 @@ mod tests {
 
         let s4 = server_mux.open_stream(Protocol::HTTP).await.unwrap();
         assert_eq!(s4.id(), 4);
+    }
+
+    /// Issue #136: a send must fail fast when the receiver is gone, instead of
+    /// blocking the session loop forever during teardown.
+    #[tokio::test]
+    async fn send_frame_fails_fast_when_receiver_dropped() {
+        let (tx, rx) = bounded_async::<PrioritizedFrame>(1);
+        drop(rx);
+        let (mux, _streams) = Multiplexer::new(tx, true);
+
+        let result = mux.send_frame(Frame::Heartbeat { timestamp: 0 }).await;
+
+        assert!(
+            result.is_err(),
+            "send to a closed frame_tx must return an error"
+        );
+    }
+
+    /// Issue #136: a send must time out (not hang) when the channel stays full
+    /// because the batched sender stopped draining (e.g. network partition).
+    ///
+    /// `start_paused` lets tokio auto-advance virtual time to the send timeout,
+    /// so the test asserts fail-fast behavior without waiting wall-clock.
+    #[tokio::test(start_paused = true)]
+    async fn send_frame_times_out_when_channel_full() {
+        let (tx, _rx) = bounded_async::<PrioritizedFrame>(1);
+        let (mux, _streams) = Multiplexer::new(tx, true);
+
+        // Fill the single slot; `_rx` is kept alive but never drained.
+        mux.send_frame(Frame::Heartbeat { timestamp: 0 })
+            .await
+            .expect("first send fills the only slot");
+
+        let result = mux.send_frame(Frame::Heartbeat { timestamp: 1 }).await;
+
+        assert!(
+            result.is_err(),
+            "send to a full frame_tx must time out rather than hang"
+        );
+    }
+
+    /// Issue #136: `VirtualStream::poll_write` must not block forever when the
+    /// wire channel is full; the bounded send surfaces an error instead.
+    #[tokio::test(start_paused = true)]
+    async fn virtual_stream_write_times_out_when_channel_full() {
+        use tokio::io::AsyncWriteExt;
+
+        let (tx, _rx) = bounded_async::<PrioritizedFrame>(1);
+        let (mux, _streams) = Multiplexer::new(tx, true);
+
+        // `open_stream` consumes the only channel slot with its OpenStream frame.
+        let mut stream = mux
+            .open_stream(Protocol::HTTP)
+            .await
+            .expect("open_stream uses the only slot");
+
+        // Channel is now full and never drained: the write must fail fast.
+        let result = stream.write(b"hello").await;
+
+        assert!(
+            result.is_err(),
+            "write to a full frame_tx must time out rather than hang"
+        );
     }
 }

--- a/ferrotunnel-core/src/stream/multiplexer.rs
+++ b/ferrotunnel-core/src/stream/multiplexer.rs
@@ -138,7 +138,7 @@ impl Multiplexer {
 
     /// Send a frame directly to the wire (priority derived from frame type and stream).
     ///
-    /// Bounded by [`FRAME_SEND_TIMEOUT`] so a full or torn-down `frame_tx`
+    /// Bounded by a fixed `FRAME_SEND_TIMEOUT` so a full or torn-down `frame_tx`
     /// channel fails fast instead of blocking the caller forever (issue #136).
     pub async fn send_frame(&self, frame: Frame) -> Result<()> {
         let priority = Self::priority_for_frame(&frame, &self.stream_priorities);

--- a/ferrotunnel-core/src/transport/tcp_frame.rs
+++ b/ferrotunnel-core/src/transport/tcp_frame.rs
@@ -10,8 +10,15 @@ use futures::StreamExt;
 use kanal::AsyncSender;
 use std::future::Future;
 use std::pin::Pin;
+use std::time::Duration;
 use tokio::io::AsyncRead;
+use tokio::time::timeout;
 use tokio_util::codec::FramedRead;
+
+/// Maximum time to wait when pushing a frame to the batched-sender channel
+/// before treating the peer as unreachable. Bounds every send so a full or
+/// closed channel during teardown cannot block the caller forever (#136).
+const FRAME_SEND_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Sends frames over TCP by pushing to the channel consumed by the batched sender task.
 #[derive(Clone)]
@@ -30,10 +37,14 @@ impl FrameSender for TcpFrameSender {
         let tx = self.tx.clone();
         Box::pin(async move {
             // Trait API has no priority; use Normal when sending via trait.
-            tx.send((StreamPriority::Normal, frame))
-                .await
-                .map_err(|e| ferrotunnel_common::TunnelError::Protocol(e.to_string()))?;
-            Ok(())
+            // Fail fast on a full/closed channel instead of blocking forever (#136).
+            match timeout(FRAME_SEND_TIMEOUT, tx.send((StreamPriority::Normal, frame))).await {
+                Ok(Ok(())) => Ok(()),
+                Ok(Err(e)) => Err(ferrotunnel_common::TunnelError::Protocol(e.to_string())),
+                Err(_) => Err(ferrotunnel_common::TunnelError::Protocol(
+                    "timed out sending frame to wire channel".into(),
+                )),
+            }
         })
     }
 }

--- a/ferrotunnel-core/src/tunnel/accept_backoff.rs
+++ b/ferrotunnel-core/src/tunnel/accept_backoff.rs
@@ -1,0 +1,147 @@
+//! Backoff for server accept loops hitting persistent transient errors.
+//!
+//! On a persistent `accept` failure (e.g. the TLS acceptor rejecting every
+//! connection, or `EMFILE`/`ENFILE` while file descriptors stay exhausted) an
+//! accept loop without a delay busy-spins at 100% CPU and floods the logs. This
+//! helper applies an exponential, jittered backoff (capped at 1s) and
+//! rate-limits the warning so a persistent error does not flood the logs. The
+//! backoff resets after a successful accept.
+//!
+//! This mirrors the HTTP ingress helper in
+//! `ferrotunnel-http/src/accept_errors.rs`; it is duplicated here so that
+//! `ferrotunnel-core` does not depend on `ferrotunnel-http`.
+
+use crate::reconnect::{Backoff, BackoffConfig};
+use std::io;
+use std::time::Duration;
+
+/// File descriptor exhaustion is transient for accept loops: dropping other
+/// connections or raising limits can make the listener usable again.
+#[cfg(unix)]
+use libc::{EMFILE, ENFILE};
+
+/// Exponential backoff for an accept loop that keeps hitting transient errors.
+pub(crate) struct AcceptBackoff {
+    backoff: Backoff,
+    consecutive: u64,
+}
+
+impl Default for AcceptBackoff {
+    fn default() -> Self {
+        Self {
+            // Millisecond-scale, capped at 1s: long enough to stop pegging a
+            // core, short enough that recovery (freed fds) is picked up fast.
+            backoff: Backoff::new(BackoffConfig {
+                base: Duration::from_millis(5),
+                max: Duration::from_secs(1),
+                factor: 2.0,
+                jitter: 0.3,
+            }),
+            consecutive: 0,
+        }
+    }
+}
+
+impl AcceptBackoff {
+    /// Reset after a successful accept so the next error starts from the base
+    /// delay again.
+    pub(crate) fn reset(&mut self) {
+        self.backoff.reset();
+        self.consecutive = 0;
+    }
+
+    /// Record a transient accept failure. Returns the delay to sleep before the
+    /// next `accept()` and whether this failure should be logged (logging is
+    /// rate-limited so a persistent error does not flood the logs).
+    pub(crate) fn record_failure(&mut self) -> (Duration, bool) {
+        self.consecutive += 1;
+        let should_log = self.consecutive == 1 || self.consecutive.is_multiple_of(50);
+        (self.backoff.next_delay(), should_log)
+    }
+}
+
+/// Whether an accept error is transient and worth retrying after a backoff.
+pub(crate) fn is_transient_accept_error(error: &io::Error) -> bool {
+    matches!(
+        error.kind(),
+        io::ErrorKind::Interrupted
+            | io::ErrorKind::WouldBlock
+            | io::ErrorKind::ConnectionAborted
+            | io::ErrorKind::ConnectionReset
+    ) || is_fd_exhaustion(error)
+}
+
+#[cfg(unix)]
+fn is_fd_exhaustion(error: &io::Error) -> bool {
+    matches!(error.raw_os_error(), Some(EMFILE | ENFILE))
+}
+
+#[cfg(not(unix))]
+fn is_fd_exhaustion(_error: &io::Error) -> bool {
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{is_transient_accept_error, AcceptBackoff};
+    use std::io;
+
+    #[test]
+    fn backoff_grows_then_resets() {
+        let mut backoff = AcceptBackoff::default();
+
+        let (first, log_first) = backoff.record_failure();
+        let (second, _) = backoff.record_failure();
+        // Delay escalates while the error persists.
+        assert!(second >= first);
+        // The first consecutive failure is always logged.
+        assert!(log_first);
+
+        backoff.reset();
+        // After a successful accept the next failure starts logging again.
+        let (_, log_after_reset) = backoff.record_failure();
+        assert!(log_after_reset);
+    }
+
+    #[test]
+    fn backoff_rate_limits_logging() {
+        let mut backoff = AcceptBackoff::default();
+        let logged = (0..120).filter(|_| backoff.record_failure().1).count();
+        // 1st, 50th, 100th -> 3 log lines out of 120 failures.
+        assert_eq!(logged, 3);
+    }
+
+    #[test]
+    fn classifies_retryable_accept_errors() {
+        for kind in [
+            io::ErrorKind::Interrupted,
+            io::ErrorKind::WouldBlock,
+            io::ErrorKind::ConnectionAborted,
+            io::ErrorKind::ConnectionReset,
+        ] {
+            assert!(is_transient_accept_error(&io::Error::new(kind, "accept")));
+        }
+    }
+
+    #[test]
+    fn classifies_fatal_accept_errors() {
+        for kind in [
+            io::ErrorKind::AddrNotAvailable,
+            io::ErrorKind::InvalidInput,
+            io::ErrorKind::PermissionDenied,
+        ] {
+            assert!(!is_transient_accept_error(&io::Error::new(kind, "accept")));
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn classifies_file_descriptor_exhaustion_as_retryable() {
+        assert!(is_transient_accept_error(&io::Error::from_raw_os_error(
+            libc::EMFILE
+        )));
+        assert!(is_transient_accept_error(&io::Error::from_raw_os_error(
+            libc::ENFILE
+        )));
+    }
+}

--- a/ferrotunnel-core/src/tunnel/mod.rs
+++ b/ferrotunnel-core/src/tunnel/mod.rs
@@ -1,3 +1,4 @@
+mod accept_backoff;
 pub mod client;
 mod common;
 pub mod server;

--- a/ferrotunnel-core/src/tunnel/server.rs
+++ b/ferrotunnel-core/src/tunnel/server.rs
@@ -28,6 +28,9 @@ use crate::transport::quic;
 
 const DEFAULT_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
 
+/// Interval between periodic stale-session cleanup passes.
+const SESSION_CLEANUP_INTERVAL: Duration = Duration::from_secs(30);
+
 pub struct TunnelServer {
     addr: SocketAddr,
     auth_token: String,
@@ -36,6 +39,22 @@ pub struct TunnelServer {
     handshake_timeout: Duration,
     resource_limits: ServerResourceLimits,
     transport_config: TransportConfig,
+    /// Handle to the periodic session-cleanup task.
+    ///
+    /// Stored so the task can be aborted on shutdown (see the `Drop` impl) and
+    /// guarded so exactly one cleanup loop runs per server instance even if both
+    /// `run` and `run_quic` are invoked.
+    cleanup_handle: Option<tokio::task::JoinHandle<()>>,
+}
+
+impl Drop for TunnelServer {
+    fn drop(&mut self) {
+        // Abort the cleanup loop so it stops ticking and releases its `Arc`
+        // clone of the session store once the server is shut down.
+        if let Some(handle) = self.cleanup_handle.take() {
+            handle.abort();
+        }
+    }
 }
 
 impl TunnelServer {
@@ -48,6 +67,7 @@ impl TunnelServer {
             handshake_timeout: DEFAULT_HANDSHAKE_TIMEOUT,
             resource_limits: ServerResourceLimits::default(),
             transport_config: TransportConfig::default(),
+            cleanup_handle: None,
         }
     }
 
@@ -129,18 +149,21 @@ impl TunnelServer {
         self.sessions.clone()
     }
 
-    pub async fn run(self) -> Result<()> {
-        let listener = TcpListener::bind(self.addr).await?;
-        info!("Server listening on {}", self.addr);
+    /// Start the periodic stale-session cleanup task exactly once.
+    ///
+    /// The `JoinHandle` is stored on the server so the loop can be aborted when
+    /// the server is dropped. If a task is already running this is a no-op,
+    /// guaranteeing a single cleanup loop per server instance even when both
+    /// `run` and `run_quic` are called.
+    fn start_cleanup_task(&mut self) {
+        if self.cleanup_handle.is_some() {
+            return;
+        }
 
-        let sessions = self.sessions.clone();
+        let cleanup_sessions = self.sessions.clone();
         let timeout = self.session_timeout;
-        let handshake_timeout = self.handshake_timeout;
-
-        // Spawn session cleanup task
-        let cleanup_sessions = sessions.clone();
-        tokio::spawn(async move {
-            let mut interval = tokio::time::interval(Duration::from_secs(30));
+        let handle = tokio::spawn(async move {
+            let mut interval = tokio::time::interval(SESSION_CLEANUP_INTERVAL);
             loop {
                 interval.tick().await;
                 let count = cleanup_sessions.cleanup_stale_sessions(timeout);
@@ -149,6 +172,17 @@ impl TunnelServer {
                 }
             }
         });
+        self.cleanup_handle = Some(handle);
+    }
+
+    pub async fn run(mut self) -> Result<()> {
+        let listener = TcpListener::bind(self.addr).await?;
+        info!("Server listening on {}", self.addr);
+
+        self.start_cleanup_task();
+
+        let sessions = self.sessions.clone();
+        let handshake_timeout = self.handshake_timeout;
 
         // Back off on persistent accept errors (e.g. a failing TLS acceptor or
         // `EMFILE`) so the loop does not busy-spin at 100% CPU and flood logs.
@@ -372,7 +406,7 @@ impl TunnelServer {
     ///
     /// This is separate from `run()` which uses TCP. Both can run simultaneously
     /// on different ports.
-    pub async fn run_quic(self, quic_addr: SocketAddr) -> Result<()> {
+    pub async fn run_quic(mut self, quic_addr: SocketAddr) -> Result<()> {
         let quic_config = match &self.transport_config {
             TransportConfig::Quic(c) => c.clone(),
             _ => {
@@ -385,22 +419,10 @@ impl TunnelServer {
         let endpoint = quic::create_server_endpoint(&quic_config, quic_addr)?;
         info!("QUIC server listening on {}", quic_addr);
 
-        let sessions = self.sessions.clone();
-        let timeout = self.session_timeout;
-        let handshake_timeout = self.handshake_timeout;
+        self.start_cleanup_task();
 
-        // Spawn session cleanup task
-        let cleanup_sessions = sessions.clone();
-        tokio::spawn(async move {
-            let mut interval = tokio::time::interval(Duration::from_secs(30));
-            loop {
-                interval.tick().await;
-                let count = cleanup_sessions.cleanup_stale_sessions(timeout);
-                if count > 0 {
-                    info!("Cleaned up {} stale sessions", count);
-                }
-            }
-        });
+        let sessions = self.sessions.clone();
+        let handshake_timeout = self.handshake_timeout;
 
         // Back off on persistent accept errors so the loop does not busy-spin
         // at 100% CPU and flood logs (e.g. `EMFILE` while fds stay exhausted).
@@ -779,5 +801,57 @@ mod tests {
             TunnelError::Timeout(msg) if msg.contains("server handshake timed out")
         ));
         assert_eq!(limits.available_sessions(), 1);
+    }
+
+    #[tokio::test]
+    async fn cleanup_task_spawns_only_once() {
+        let mut server = TunnelServer::new("127.0.0.1:0".parse().unwrap(), "token".to_string());
+        assert!(server.cleanup_handle.is_none());
+
+        server.start_cleanup_task();
+        let first_id = server
+            .cleanup_handle
+            .as_ref()
+            .expect("cleanup task should be spawned")
+            .id();
+
+        // A second call (e.g. if both run() and run_quic() execute) must not
+        // spawn a competing cleanup loop.
+        server.start_cleanup_task();
+        let second_id = server
+            .cleanup_handle
+            .as_ref()
+            .expect("cleanup task should still be present")
+            .id();
+
+        assert_eq!(first_id, second_id, "a second cleanup loop was spawned");
+    }
+
+    #[tokio::test]
+    async fn cleanup_task_aborted_when_server_dropped() {
+        let mut server = TunnelServer::new("127.0.0.1:0".parse().unwrap(), "token".to_string());
+        server.start_cleanup_task();
+
+        let abort = server
+            .cleanup_handle
+            .as_ref()
+            .expect("cleanup task should be spawned")
+            .abort_handle();
+        assert!(!abort.is_finished());
+
+        // Dropping the server simulates shutdown; the cleanup task must stop.
+        drop(server);
+
+        // The abort is processed asynchronously; poll until the task stops.
+        for _ in 0..100 {
+            if abort.is_finished() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+        assert!(
+            abort.is_finished(),
+            "cleanup task should be aborted after server drop"
+        );
     }
 }

--- a/ferrotunnel-core/src/tunnel/server.rs
+++ b/ferrotunnel-core/src/tunnel/server.rs
@@ -9,7 +9,7 @@ use crate::tunnel::session::{Session, SessionStoreBackend, ShardedSessionStore};
 use ferrotunnel_common::{Result, TunnelError};
 use ferrotunnel_protocol::codec::TunnelCodec;
 use ferrotunnel_protocol::constants::{MAX_PROTOCOL_VERSION, MIN_PROTOCOL_VERSION};
-use ferrotunnel_protocol::frame::{Frame, HandshakeFrame, HandshakeStatus};
+use ferrotunnel_protocol::frame::{CloseReason, Frame, HandshakeFrame, HandshakeStatus};
 use futures::{SinkExt, StreamExt};
 use kanal::bounded_async;
 use std::net::SocketAddr;
@@ -367,12 +367,49 @@ impl TunnelServer {
                 m.record_decode(1, bytes, decode_start.elapsed());
             }
 
-            // Update heartbeat for any activity
-            if let Some(mut session) = sessions.get_mut(&session_id) {
+            // Update heartbeat for any activity and snapshot the rate limiter.
+            let rate_limiter = if let Some(mut session) = sessions.get_mut(&session_id) {
                 session.update_heartbeat();
+                session.rate_limiter.clone()
             } else {
                 // Session removed (shutdown/timeout)
                 return Err(TunnelError::Protocol("Session not found".into()));
+            };
+
+            // Enforce per-session rate limits on the hot path (issue #119).
+            // Fail closed: deny stream opens and drop data frames when over limit.
+            if let Some(limiter) = &rate_limiter {
+                match &frame {
+                    Frame::OpenStream(open) => {
+                        if limiter.check_stream_open().is_err() {
+                            let stream_id = open.stream_id;
+                            warn!(
+                                session_id = %session_id,
+                                stream_id,
+                                "Stream-open rate limit exceeded; denying stream"
+                            );
+                            // Signal denial to the client so it does not wait indefinitely.
+                            let _ = multiplexer
+                                .send_frame(Frame::CloseStream {
+                                    stream_id,
+                                    reason: CloseReason::Error("rate limited".into()),
+                                })
+                                .await;
+                            continue;
+                        }
+                    }
+                    Frame::Data { data, .. } => {
+                        if limiter.check_data(data.len()).is_err() {
+                            warn!(
+                                session_id = %session_id,
+                                bytes = data.len(),
+                                "Data rate limit exceeded; dropping data frame"
+                            );
+                            continue;
+                        }
+                    }
+                    _ => {}
+                }
             }
 
             match frame {
@@ -852,6 +889,75 @@ mod tests {
         assert!(
             abort.is_finished(),
             "cleanup task should be aborted after server drop"
+        );
+    }
+
+    #[tokio::test]
+    async fn process_messages_enforces_stream_open_rate_limit() {
+        use crate::rate_limit::{RateLimiterConfig, SessionRateLimiter};
+        use ferrotunnel_protocol::frame::{OpenStreamFrame, Protocol, StreamPriority};
+        use std::num::NonZeroU32;
+
+        // Duplex channel: the "client" half writes frames the server reads.
+        let (client_side, server_side) = tokio::io::duplex(64 * 1024);
+
+        // Multiplexer wired to a drained outbound channel so denial frames never block.
+        let (frame_tx, frame_rx) = bounded_async::<PrioritizedFrame>(1024);
+        tokio::spawn(async move { while frame_rx.recv().await.is_ok() {} });
+        let (multiplexer, new_stream_rx) = Multiplexer::new(frame_tx, false);
+
+        // Session with a tight stream-open limiter: capacity = 1 (1/s, burst 1).
+        let session_id = Uuid::new_v4();
+        let tight = RateLimiterConfig {
+            streams_per_sec: NonZeroU32::new(1).unwrap(),
+            bytes_per_sec: NonZeroU32::new(1000).unwrap(),
+            burst_factor: NonZeroU32::new(1).unwrap(),
+        };
+        let sessions = SessionStoreBackend::default();
+        let session = Session::new(
+            session_id,
+            "tight-tunnel".into(),
+            "127.0.0.1:0".parse().unwrap(),
+            "tok".into(),
+            vec![],
+            Some(AnyMultiplexer::Tcp(multiplexer.clone())),
+        )
+        .with_rate_limiter(SessionRateLimiter::new(&tight));
+        sessions.add(session).unwrap();
+
+        // Client encodes three OpenStream frames, then closes (EOF ends the loop).
+        let mut client = Framed::new(client_side, TunnelCodec::new());
+        for stream_id in [1u32, 3, 5] {
+            client
+                .send(Frame::OpenStream(Box::new(OpenStreamFrame {
+                    stream_id,
+                    protocol: Protocol::TCP,
+                    headers: vec![],
+                    body_hint: None,
+                    priority: StreamPriority::default(),
+                })))
+                .await
+                .unwrap();
+        }
+        client.flush().await.unwrap();
+        drop(client);
+
+        // Drive the production hot path.
+        let server_stream: BoxedStream = Box::pin(server_side);
+        let (read_half, _write_half) = tokio::io::split(server_stream);
+        let framed_read = tokio_util::codec::FramedRead::new(read_half, TunnelCodec::new());
+        TunnelServer::process_messages(framed_read, session_id, sessions, multiplexer)
+            .await
+            .unwrap();
+
+        // Only the first stream-open passes enforcement; the rest are denied.
+        let mut accepted = 0;
+        while new_stream_rx.try_recv().ok().flatten().is_some() {
+            accepted += 1;
+        }
+        assert_eq!(
+            accepted, 1,
+            "rate limiter must deny stream opens over limit"
         );
     }
 }

--- a/ferrotunnel-core/src/tunnel/server.rs
+++ b/ferrotunnel-core/src/tunnel/server.rs
@@ -3,6 +3,7 @@ use crate::resource_limits::{ServerResourceLimits, SessionPermit};
 use crate::stream::{AnyMultiplexer, Multiplexer, PrioritizedFrame};
 use crate::transport::batched_sender::run_batched_sender;
 use crate::transport::{self, BoxedStream, TransportConfig};
+use crate::tunnel::accept_backoff::{is_transient_accept_error, AcceptBackoff};
 use crate::tunnel::common::{clamp_u128_to_u64, read_initial_handshake_frame};
 use crate::tunnel::session::{Session, SessionStoreBackend, ShardedSessionStore};
 use ferrotunnel_common::{Result, TunnelError};
@@ -17,7 +18,7 @@ use tokio::net::TcpListener;
 #[cfg(feature = "quic")]
 use tokio::time::timeout;
 use tokio_util::codec::Framed;
-use tracing::{error, info, warn};
+use tracing::{info, warn};
 use uuid::Uuid;
 
 #[cfg(feature = "quic")]
@@ -149,39 +150,56 @@ impl TunnelServer {
             }
         });
 
+        // Back off on persistent accept errors (e.g. a failing TLS acceptor or
+        // `EMFILE`) so the loop does not busy-spin at 100% CPU and flood logs.
+        let mut accept_backoff = AcceptBackoff::default();
         loop {
-            match transport::accept(&self.transport_config, &listener).await {
-                Ok((stream, addr)) => {
-                    let session_permit = match self.resource_limits.try_acquire_session() {
-                        Ok(permit) => permit,
-                        Err(e) => {
-                            warn!("Rejecting connection from {}: {}", addr, e);
-                            continue;
-                        }
-                    };
-
-                    let sessions = sessions.clone();
-                    let token = self.auth_token.clone();
-
-                    tokio::spawn(async move {
-                        if let Err(e) = Self::handle_connection(
-                            stream,
-                            addr,
-                            sessions,
-                            token,
-                            session_permit,
-                            handshake_timeout,
-                        )
-                        .await
-                        {
-                            warn!("Connection error for {}: {}", addr, e);
-                        }
-                    });
+            let (stream, addr) = match transport::accept(&self.transport_config, &listener).await {
+                Ok(connection) => {
+                    accept_backoff.reset();
+                    connection
                 }
+                Err(e) if is_transient_accept_error(&e) => {
+                    let (delay, should_log) = accept_backoff.record_failure();
+                    if should_log {
+                        warn!(
+                            bind_addr = %self.addr,
+                            error = %e,
+                            backoff_ms = delay.as_millis(),
+                            "Transient accept error; backing off"
+                        );
+                    }
+                    tokio::time::sleep(delay).await;
+                    continue;
+                }
+                Err(e) => return Err(e.into()),
+            };
+
+            let session_permit = match self.resource_limits.try_acquire_session() {
+                Ok(permit) => permit,
                 Err(e) => {
-                    error!("Accept error: {}", e);
+                    warn!("Rejecting connection from {}: {}", addr, e);
+                    continue;
                 }
-            }
+            };
+
+            let sessions = sessions.clone();
+            let token = self.auth_token.clone();
+
+            tokio::spawn(async move {
+                if let Err(e) = Self::handle_connection(
+                    stream,
+                    addr,
+                    sessions,
+                    token,
+                    session_permit,
+                    handshake_timeout,
+                )
+                .await
+                {
+                    warn!("Connection error for {}: {}", addr, e);
+                }
+            });
         }
     }
 
@@ -384,39 +402,56 @@ impl TunnelServer {
             }
         });
 
+        // Back off on persistent accept errors so the loop does not busy-spin
+        // at 100% CPU and flood logs (e.g. `EMFILE` while fds stay exhausted).
+        let mut accept_backoff = AcceptBackoff::default();
         loop {
-            match quic::accept(&endpoint).await {
-                Ok((connection, addr)) => {
-                    let session_permit = match self.resource_limits.try_acquire_session() {
-                        Ok(permit) => permit,
-                        Err(e) => {
-                            warn!("Rejecting QUIC connection from {}: {}", addr, e);
-                            continue;
-                        }
-                    };
-
-                    let sessions = sessions.clone();
-                    let token = self.auth_token.clone();
-
-                    tokio::spawn(async move {
-                        if let Err(e) = Self::handle_quic_connection(
-                            connection,
-                            addr,
-                            sessions,
-                            token,
-                            session_permit,
-                            handshake_timeout,
-                        )
-                        .await
-                        {
-                            warn!("QUIC connection error for {}: {}", addr, e);
-                        }
-                    });
+            let (connection, addr) = match quic::accept(&endpoint).await {
+                Ok(accepted) => {
+                    accept_backoff.reset();
+                    accepted
                 }
+                Err(e) if is_transient_accept_error(&e) => {
+                    let (delay, should_log) = accept_backoff.record_failure();
+                    if should_log {
+                        warn!(
+                            bind_addr = %quic_addr,
+                            error = %e,
+                            backoff_ms = delay.as_millis(),
+                            "Transient QUIC accept error; backing off"
+                        );
+                    }
+                    tokio::time::sleep(delay).await;
+                    continue;
+                }
+                Err(e) => return Err(e.into()),
+            };
+
+            let session_permit = match self.resource_limits.try_acquire_session() {
+                Ok(permit) => permit,
                 Err(e) => {
-                    error!("QUIC accept error: {}", e);
+                    warn!("Rejecting QUIC connection from {}: {}", addr, e);
+                    continue;
                 }
-            }
+            };
+
+            let sessions = sessions.clone();
+            let token = self.auth_token.clone();
+
+            tokio::spawn(async move {
+                if let Err(e) = Self::handle_quic_connection(
+                    connection,
+                    addr,
+                    sessions,
+                    token,
+                    session_permit,
+                    handshake_timeout,
+                )
+                .await
+                {
+                    warn!("QUIC connection error for {}: {}", addr, e);
+                }
+            });
         }
     }
 

--- a/ferrotunnel-core/src/tunnel/server.rs
+++ b/ferrotunnel-core/src/tunnel/server.rs
@@ -386,33 +386,29 @@ impl TunnelServer {
             // Fail closed: deny stream opens and drop data frames when over limit.
             if let Some(limiter) = &rate_limiter {
                 match &frame {
-                    Frame::OpenStream(open) => {
-                        if limiter.check_stream_open().is_err() {
-                            let stream_id = open.stream_id;
-                            warn!(
-                                session_id = %session_id,
+                    Frame::OpenStream(open) if limiter.check_stream_open().is_err() => {
+                        let stream_id = open.stream_id;
+                        warn!(
+                            session_id = %session_id,
+                            stream_id,
+                            "Stream-open rate limit exceeded; denying stream"
+                        );
+                        // Signal denial to the client so it does not wait indefinitely.
+                        let _ = multiplexer
+                            .send_frame(Frame::CloseStream {
                                 stream_id,
-                                "Stream-open rate limit exceeded; denying stream"
-                            );
-                            // Signal denial to the client so it does not wait indefinitely.
-                            let _ = multiplexer
-                                .send_frame(Frame::CloseStream {
-                                    stream_id,
-                                    reason: CloseReason::Error("rate limited".into()),
-                                })
-                                .await;
-                            continue;
-                        }
+                                reason: CloseReason::Error("rate limited".into()),
+                            })
+                            .await;
+                        continue;
                     }
-                    Frame::Data { data, .. } => {
-                        if limiter.check_data(data.len()).is_err() {
-                            warn!(
-                                session_id = %session_id,
-                                bytes = data.len(),
-                                "Data rate limit exceeded; dropping data frame"
-                            );
-                            continue;
-                        }
+                    Frame::Data { data, .. } if limiter.check_data(data.len()).is_err() => {
+                        warn!(
+                            session_id = %session_id,
+                            bytes = data.len(),
+                            "Data rate limit exceeded; dropping data frame"
+                        );
+                        continue;
                     }
                     _ => {}
                 }

--- a/ferrotunnel-core/src/tunnel/server.rs
+++ b/ferrotunnel-core/src/tunnel/server.rs
@@ -966,4 +966,90 @@ mod tests {
             "rate limiter must deny stream opens over limit"
         );
     }
+
+    #[tokio::test]
+    async fn process_messages_enforces_data_byte_rate_limit() {
+        use crate::rate_limit::{RateLimiterConfig, SessionRateLimiter};
+        use bytes::Bytes;
+        use ferrotunnel_protocol::frame::{OpenStreamFrame, Protocol, StreamPriority};
+        use std::num::NonZeroU32;
+        use tokio::io::AsyncReadExt;
+        use tokio::time::timeout;
+
+        let (client_side, server_side) = tokio::io::duplex(64 * 1024);
+
+        let (frame_tx, frame_rx) = bounded_async::<PrioritizedFrame>(1024);
+        tokio::spawn(async move { while frame_rx.recv().await.is_ok() {} });
+        let (multiplexer, new_stream_rx) = Multiplexer::new(frame_tx, false);
+
+        // Generous stream-open budget but a byte budget of exactly one frame
+        // (capacity = 8 bytes) so the first data frame consumes the whole quota
+        // and the second is over budget.
+        let session_id = Uuid::new_v4();
+        let tight = RateLimiterConfig {
+            streams_per_sec: NonZeroU32::new(100).unwrap(),
+            bytes_per_sec: NonZeroU32::new(8).unwrap(),
+            burst_factor: NonZeroU32::new(1).unwrap(),
+        };
+        let sessions = SessionStoreBackend::default();
+        let session = Session::new(
+            session_id,
+            "tight-bytes".into(),
+            "127.0.0.1:0".parse().unwrap(),
+            "tok".into(),
+            vec![],
+            Some(AnyMultiplexer::Tcp(multiplexer.clone())),
+        )
+        .with_rate_limiter(SessionRateLimiter::new(&tight));
+        sessions.add(session).unwrap();
+
+        // Open stream 1, send 8 bytes (the whole 8-byte budget), then 8 more
+        // bytes (over budget -> must be dropped by the Frame::Data limiter arm).
+        let mut client = Framed::new(client_side, TunnelCodec::new());
+        client
+            .send(Frame::OpenStream(Box::new(OpenStreamFrame {
+                stream_id: 1,
+                protocol: Protocol::TCP,
+                headers: vec![],
+                body_hint: None,
+                priority: StreamPriority::default(),
+            })))
+            .await
+            .unwrap();
+        for payload in [&b"AAAAAAAA"[..], &b"BBBBBBBB"[..]] {
+            client
+                .send(Frame::Data {
+                    stream_id: 1,
+                    data: Bytes::copy_from_slice(payload),
+                    end_of_stream: false,
+                })
+                .await
+                .unwrap();
+        }
+        client.flush().await.unwrap();
+        drop(client);
+
+        let server_stream: BoxedStream = Box::pin(server_side);
+        let (read_half, _write_half) = tokio::io::split(server_stream);
+        let framed_read = tokio_util::codec::FramedRead::new(read_half, TunnelCodec::new());
+        // Keep a multiplexer clone alive so the opened stream's channel stays open
+        // after `process_messages` returns; otherwise a dropped (rate-limited) frame
+        // would be indistinguishable from channel-close EOF.
+        let _keepalive = multiplexer.clone();
+        TunnelServer::process_messages(framed_read, session_id, sessions, multiplexer)
+            .await
+            .unwrap();
+
+        // The opened stream receives only the first (in-budget) data frame; the
+        // second is dropped, so a follow-up read has nothing more to deliver.
+        let mut stream = new_stream_rx.recv().await.unwrap();
+        let mut buf = vec![0u8; 64];
+        let first = stream.read(&mut buf).await.unwrap();
+        assert_eq!(&buf[..first], b"AAAAAAAA");
+        let second = timeout(Duration::from_millis(300), stream.read(&mut buf)).await;
+        assert!(
+            second.is_err(),
+            "over-budget data frame must be dropped by the rate limiter"
+        );
+    }
 }

--- a/ferrotunnel-core/src/tunnel/server.rs
+++ b/ferrotunnel-core/src/tunnel/server.rs
@@ -193,20 +193,26 @@ impl TunnelServer {
                     accept_backoff.reset();
                     connection
                 }
-                Err(e) if is_transient_accept_error(&e) => {
+                // `transport::accept` performs the per-connection TLS handshake,
+                // so an error here is almost always a single bad/half-open
+                // connection (e.g. a plain-TCP health probe against a TLS
+                // listener), not a broken listener. Never terminate the accept
+                // loop; log (rate-limited) and back off so a persistent error
+                // (failing acceptor, EMFILE) cannot busy-spin a core.
+                Err(e) => {
                     let (delay, should_log) = accept_backoff.record_failure();
                     if should_log {
                         warn!(
                             bind_addr = %self.addr,
                             error = %e,
+                            transient = is_transient_accept_error(&e),
                             backoff_ms = delay.as_millis(),
-                            "Transient accept error; backing off"
+                            "Accept error; backing off"
                         );
                     }
                     tokio::time::sleep(delay).await;
                     continue;
                 }
-                Err(e) => return Err(e.into()),
             };
 
             let session_permit = match self.resource_limits.try_acquire_session() {
@@ -470,20 +476,24 @@ impl TunnelServer {
                     accept_backoff.reset();
                     accepted
                 }
-                Err(e) if is_transient_accept_error(&e) => {
+                // QUIC acceptance includes the per-connection handshake, so an
+                // error is almost always one bad connection, not a dead
+                // endpoint. Never terminate the loop; log (rate-limited) and
+                // back off so a persistent failure cannot busy-spin a core.
+                Err(e) => {
                     let (delay, should_log) = accept_backoff.record_failure();
                     if should_log {
                         warn!(
                             bind_addr = %quic_addr,
                             error = %e,
+                            transient = is_transient_accept_error(&e),
                             backoff_ms = delay.as_millis(),
-                            "Transient QUIC accept error; backing off"
+                            "QUIC accept error; backing off"
                         );
                     }
                     tokio::time::sleep(delay).await;
                     continue;
                 }
-                Err(e) => return Err(e.into()),
             };
 
             let session_permit = match self.resource_limits.try_acquire_session() {

--- a/ferrotunnel-core/src/tunnel/session.rs
+++ b/ferrotunnel-core/src/tunnel/session.rs
@@ -1,4 +1,4 @@
-use crate::rate_limit::SessionRateLimiter;
+use crate::rate_limit::{RateLimiterConfig, SessionRateLimiter};
 use crate::stream::AnyMultiplexer;
 use dashmap::DashMap;
 use std::collections::hash_map::DefaultHasher;
@@ -47,7 +47,9 @@ impl Session {
             last_heartbeat: now,
             capabilities,
             multiplexer,
-            rate_limiter: None,
+            // Enforce per-session limits by default so the limiter is never dead code.
+            // Callers may override via [`Self::with_rate_limiter`].
+            rate_limiter: Some(SessionRateLimiter::new(&RateLimiterConfig::default())),
         }
     }
 

--- a/ferrotunnel-http/Cargo.toml
+++ b/ferrotunnel-http/Cargo.toml
@@ -21,6 +21,7 @@ hyper = { version = "1", features = ["full", "http2"] }
 http-body-util = "0.1"
 hyper-util = { version = "0.1", features = ["full", "server-auto", "tokio"] }
 bytes = { workspace = true }
+libc = "0.2"
 tracing = "0.1"
 uuid = { workspace = true }
 futures = "0.3"

--- a/ferrotunnel-http/src/accept_errors.rs
+++ b/ferrotunnel-http/src/accept_errors.rs
@@ -1,0 +1,66 @@
+use std::io;
+
+/// File descriptor exhaustion is transient for accept loops: dropping other
+/// connections or raising limits can make the listener usable again.
+#[cfg(unix)]
+use libc::{EMFILE, ENFILE};
+
+pub(crate) fn is_transient_accept_error(error: &io::Error) -> bool {
+    matches!(
+        error.kind(),
+        io::ErrorKind::Interrupted
+            | io::ErrorKind::WouldBlock
+            | io::ErrorKind::ConnectionAborted
+            | io::ErrorKind::ConnectionReset
+    ) || is_fd_exhaustion(error)
+}
+
+#[cfg(unix)]
+fn is_fd_exhaustion(error: &io::Error) -> bool {
+    matches!(error.raw_os_error(), Some(EMFILE | ENFILE))
+}
+
+#[cfg(not(unix))]
+fn is_fd_exhaustion(_error: &io::Error) -> bool {
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_transient_accept_error;
+    use std::io;
+
+    #[test]
+    fn classifies_retryable_accept_errors() {
+        for kind in [
+            io::ErrorKind::Interrupted,
+            io::ErrorKind::WouldBlock,
+            io::ErrorKind::ConnectionAborted,
+            io::ErrorKind::ConnectionReset,
+        ] {
+            assert!(is_transient_accept_error(&io::Error::new(kind, "accept")));
+        }
+    }
+
+    #[test]
+    fn classifies_fatal_accept_errors() {
+        for kind in [
+            io::ErrorKind::AddrNotAvailable,
+            io::ErrorKind::InvalidInput,
+            io::ErrorKind::PermissionDenied,
+        ] {
+            assert!(!is_transient_accept_error(&io::Error::new(kind, "accept")));
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn classifies_file_descriptor_exhaustion_as_retryable() {
+        assert!(is_transient_accept_error(&io::Error::from_raw_os_error(
+            libc::EMFILE
+        )));
+        assert!(is_transient_accept_error(&io::Error::from_raw_os_error(
+            libc::ENFILE
+        )));
+    }
+}

--- a/ferrotunnel-http/src/accept_errors.rs
+++ b/ferrotunnel-http/src/accept_errors.rs
@@ -1,9 +1,54 @@
+use ferrotunnel_core::reconnect::{Backoff, BackoffConfig};
 use std::io;
+use std::time::Duration;
 
 /// File descriptor exhaustion is transient for accept loops: dropping other
 /// connections or raising limits can make the listener usable again.
 #[cfg(unix)]
 use libc::{EMFILE, ENFILE};
+
+/// Backoff for accept loops hitting a persistent transient error (e.g. `EMFILE`
+/// while file descriptors stay exhausted). Without a delay the loop would
+/// busy-spin on `accept()` at 100% CPU and flood the logs; the delay grows
+/// exponentially up to a cap and resets after a successful accept.
+pub(crate) struct AcceptBackoff {
+    backoff: Backoff,
+    consecutive: u64,
+}
+
+impl Default for AcceptBackoff {
+    fn default() -> Self {
+        Self {
+            // Millisecond-scale, capped at 1s: long enough to stop pegging a
+            // core, short enough that recovery (freed fds) is picked up fast.
+            backoff: Backoff::new(BackoffConfig {
+                base: Duration::from_millis(5),
+                max: Duration::from_secs(1),
+                factor: 2.0,
+                jitter: 0.3,
+            }),
+            consecutive: 0,
+        }
+    }
+}
+
+impl AcceptBackoff {
+    /// Reset after a successful accept so the next error starts from the base
+    /// delay again.
+    pub(crate) fn reset(&mut self) {
+        self.backoff.reset();
+        self.consecutive = 0;
+    }
+
+    /// Record a transient accept failure. Returns the delay to sleep before the
+    /// next `accept()` and whether this failure should be logged (logging is
+    /// rate-limited so a persistent error does not flood the logs).
+    pub(crate) fn record_failure(&mut self) -> (Duration, bool) {
+        self.consecutive += 1;
+        let should_log = self.consecutive == 1 || self.consecutive.is_multiple_of(50);
+        (self.backoff.next_delay(), should_log)
+    }
+}
 
 pub(crate) fn is_transient_accept_error(error: &io::Error) -> bool {
     matches!(
@@ -27,8 +72,33 @@ fn is_fd_exhaustion(_error: &io::Error) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::is_transient_accept_error;
+    use super::{is_transient_accept_error, AcceptBackoff};
     use std::io;
+
+    #[test]
+    fn backoff_grows_then_resets() {
+        let mut backoff = AcceptBackoff::default();
+
+        let (first, log_first) = backoff.record_failure();
+        let (second, _) = backoff.record_failure();
+        // Delay escalates while the error persists.
+        assert!(second >= first);
+        // The first consecutive failure is always logged.
+        assert!(log_first);
+
+        backoff.reset();
+        // After a successful accept the next failure starts logging again.
+        let (_, log_after_reset) = backoff.record_failure();
+        assert!(log_after_reset);
+    }
+
+    #[test]
+    fn backoff_rate_limits_logging() {
+        let mut backoff = AcceptBackoff::default();
+        let logged = (0..120).filter(|_| backoff.record_failure().1).count();
+        // 1st, 50th, 100th -> 3 log lines out of 120 failures.
+        assert_eq!(logged, 3);
+    }
 
     #[test]
     fn classifies_retryable_accept_errors() {

--- a/ferrotunnel-http/src/ingress.rs
+++ b/ferrotunnel-http/src/ingress.rs
@@ -1,4 +1,4 @@
-use crate::accept_errors::is_transient_accept_error;
+use crate::accept_errors::{is_transient_accept_error, AcceptBackoff};
 use ferrotunnel_common::Result;
 use ferrotunnel_core::tunnel::session::SessionStoreBackend;
 use ferrotunnel_plugin::{PluginAction, PluginRegistry, RequestContext, ResponseContext};
@@ -92,15 +92,24 @@ impl HttpIngress {
             self.addr
         );
 
+        let mut accept_backoff = AcceptBackoff::default();
         loop {
             let (stream, peer_addr) = match listener.accept().await {
-                Ok(connection) => connection,
+                Ok(connection) => {
+                    accept_backoff.reset();
+                    connection
+                }
                 Err(error) if is_transient_accept_error(&error) => {
-                    warn!(
-                        bind_addr = %self.addr,
-                        error = %error,
-                        "Transient HTTP ingress accept error; continuing"
-                    );
+                    let (delay, should_log) = accept_backoff.record_failure();
+                    if should_log {
+                        warn!(
+                            bind_addr = %self.addr,
+                            error = %error,
+                            backoff_ms = delay.as_millis(),
+                            "Transient HTTP ingress accept error; backing off"
+                        );
+                    }
+                    tokio::time::sleep(delay).await;
                     continue;
                 }
                 Err(error) => return Err(error.into()),

--- a/ferrotunnel-http/src/ingress.rs
+++ b/ferrotunnel-http/src/ingress.rs
@@ -528,7 +528,17 @@ async fn handle_request(
         .await
     {
         Ok(PluginAction::Continue | _) => {}
-        Err(e) => error!("Plugin response hook error: {}", e),
+        // A hook error (including an isolated plugin panic, see #138) leaves
+        // `proxy_res` holding the empty placeholder swapped in by the registry,
+        // so we must not fall through and ship it. Return a clean 500 instead of
+        // a silent empty 200.
+        Err(e) => {
+            error!("Plugin response hook error: {}", e);
+            return Ok(full_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Plugin processing error",
+            ));
+        }
     }
 
     let (final_parts, final_body) = proxy_res.into_parts();

--- a/ferrotunnel-http/src/ingress.rs
+++ b/ferrotunnel-http/src/ingress.rs
@@ -22,6 +22,8 @@ use tracing::{error, info, warn};
 pub struct IngressConfig {
     /// Maximum concurrent connections (default: 10000)
     pub max_connections: usize,
+    /// Maximum request body size in bytes (default: 100MB)
+    pub max_request_body_size: usize,
     /// Maximum response body size in bytes (default: 100MB)
     pub max_response_size: usize,
     /// Timeout for upstream handshake (default: 10s)
@@ -36,7 +38,8 @@ impl Default for IngressConfig {
     fn default() -> Self {
         Self {
             max_connections: 10000,
-            max_response_size: 100 * 1024 * 1024, // 100MB
+            max_request_body_size: 100 * 1024 * 1024, // 100MB
+            max_response_size: 100 * 1024 * 1024,     // 100MB
             handshake_timeout: Duration::from_secs(10),
             response_timeout: Duration::from_mins(1),
             alt_svc_header: None,
@@ -270,7 +273,20 @@ async fn handle_request(
         Protocol::HTTP
     };
 
-    let mut forward_req = Request::from_parts(parts, body.boxed());
+    // Reject oversized request bodies before forwarding upstream.
+    // A declared Content-Length over the limit is rejected up front with 413.
+    // Bodies without a Content-Length (e.g. chunked) are hard-capped by the
+    // `Limited` wrapper below so they cannot pin a permit + memory unboundedly.
+    if content_length_exceeds(&parts.headers, config.max_request_body_size) {
+        warn!("Request body exceeds max_request_body_size; rejecting with 413");
+        return Ok(full_response(
+            StatusCode::PAYLOAD_TOO_LARGE,
+            "Request body too large",
+        ));
+    }
+
+    let limited_body = http_body_util::Limited::new(body, config.max_request_body_size).boxed();
+    let mut forward_req = Request::from_parts(parts, limited_body);
 
     // HTTP/2 (gRPC) requires an absolute URI (scheme + authority).
     // Callers often send requests with a path-only URI and a Host header;
@@ -482,11 +498,17 @@ async fn handle_request(
     }
 
     // Buffer response for plugin processing
-    let body_bytes = match collect_body_with_limit(body, config.max_response_size).await {
+    let body_bytes = match collect_body_with_limit(
+        body,
+        config.max_response_size,
+        config.response_timeout,
+    )
+    .await
+    {
         Ok(bytes) => bytes,
-        Err(msg) => {
-            error!("Response body error: {}", msg);
-            return Ok(full_response(StatusCode::BAD_GATEWAY, msg));
+        Err(err) => {
+            error!("Response body error: {}", err.message());
+            return Ok(full_response(err.status(), err.message()));
         }
     };
 
@@ -518,6 +540,18 @@ async fn handle_request(
         Response::from_parts(final_parts, boxed_body),
         &config,
     ))
+}
+
+/// Returns `true` if the request declares a `Content-Length` larger than `max_size`.
+///
+/// Used to reject oversized request bodies up front with `413 Payload Too Large`
+/// before any upstream stream is opened.
+fn content_length_exceeds(headers: &hyper::HeaderMap, max_size: usize) -> bool {
+    headers
+        .get(hyper::header::CONTENT_LENGTH)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.parse::<u64>().ok())
+        .is_some_and(|len| len > max_size as u64)
 }
 
 fn is_grpc(headers: &hyper::HeaderMap) -> bool {
@@ -588,24 +622,62 @@ pub(crate) fn parse_and_normalize_host(
 /// Initial reserve for response body collection to reduce reallocations.
 const BODY_COLLECT_RESERVE: usize = 64 * 1024;
 
-/// Collect response body with a size limit to prevent denial-of-service attacks
-async fn collect_body_with_limit(
-    body: hyper::body::Incoming,
+/// Reason a buffered response body could not be collected.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BodyCollectError {
+    /// A frame did not arrive within the per-frame timeout (stalled upstream).
+    Timeout,
+    /// The collected body exceeded `max_size`.
+    TooLarge,
+    /// The upstream body stream returned a read error.
+    Read,
+}
+
+impl BodyCollectError {
+    /// HTTP status to return to the downstream client for this failure.
+    fn status(self) -> StatusCode {
+        match self {
+            BodyCollectError::Timeout => StatusCode::GATEWAY_TIMEOUT,
+            BodyCollectError::TooLarge | BodyCollectError::Read => StatusCode::BAD_GATEWAY,
+        }
+    }
+
+    /// Human-readable message for the response body and logs.
+    fn message(self) -> &'static str {
+        match self {
+            BodyCollectError::Timeout => "Upstream response body timeout",
+            BodyCollectError::TooLarge => "Response body too large",
+            BodyCollectError::Read => "Error reading response body",
+        }
+    }
+}
+
+/// Collect a response body with a size limit and a per-frame read timeout.
+///
+/// The size limit prevents unbounded memory use; the per-frame timeout ensures a
+/// stalled upstream cannot pin a connection permit and buffered memory
+/// indefinitely (mirrors the HTTP/3 ingress `collect_upstream_body`).
+async fn collect_body_with_limit<B>(
+    mut body: B,
     max_size: usize,
-) -> std::result::Result<Bytes, &'static str> {
-    use http_body_util::BodyExt;
-
+    frame_timeout: Duration,
+) -> std::result::Result<Bytes, BodyCollectError>
+where
+    B: hyper::body::Body<Data = Bytes> + Unpin,
+{
     let mut collected = Vec::with_capacity(BODY_COLLECT_RESERVE.min(max_size));
-    let mut body = body;
 
-    while let Some(frame_result) = body.frame().await {
-        let Ok(frame) = frame_result else {
-            return Err("Error reading response body");
+    loop {
+        let frame = match tokio::time::timeout(frame_timeout, body.frame()).await {
+            Ok(Some(Ok(frame))) => frame,
+            Ok(Some(Err(_))) => return Err(BodyCollectError::Read),
+            Ok(None) => break,
+            Err(_) => return Err(BodyCollectError::Timeout),
         };
 
         if let Some(data) = frame.data_ref() {
             if collected.len() + data.len() > max_size {
-                return Err("Response body too large");
+                return Err(BodyCollectError::TooLarge);
             }
             collected.extend_from_slice(data);
         }
@@ -775,5 +847,98 @@ mod tests {
     fn test_not_websocket_regular_request() {
         let headers = hyper::HeaderMap::new();
         assert!(!is_websocket_upgrade(&headers));
+    }
+
+    #[test]
+    fn content_length_exceeds_when_over_limit() {
+        let mut headers = hyper::HeaderMap::new();
+        headers.insert(hyper::header::CONTENT_LENGTH, "2048".parse().unwrap());
+        assert!(content_length_exceeds(&headers, 1024));
+    }
+
+    #[test]
+    fn content_length_within_limit_is_allowed() {
+        let mut headers = hyper::HeaderMap::new();
+        headers.insert(hyper::header::CONTENT_LENGTH, "512".parse().unwrap());
+        assert!(!content_length_exceeds(&headers, 1024));
+    }
+
+    #[test]
+    fn content_length_missing_is_allowed() {
+        let headers = hyper::HeaderMap::new();
+        assert!(!content_length_exceeds(&headers, 1024));
+    }
+
+    #[test]
+    fn content_length_non_numeric_is_allowed() {
+        let mut headers = hyper::HeaderMap::new();
+        headers.insert(
+            hyper::header::CONTENT_LENGTH,
+            "not-a-number".parse().unwrap(),
+        );
+        assert!(!content_length_exceeds(&headers, 1024));
+    }
+
+    // Acceptance (1): an oversized request body is rejected. The `Limited`
+    // wrapper used on the forwarded request body errors once the cap is passed,
+    // hard-capping bodies that have no declared Content-Length.
+    #[tokio::test]
+    async fn oversized_request_body_is_rejected_by_limited() {
+        let body = http_body_util::Full::new(Bytes::from(vec![0u8; 2048]));
+        let limited = http_body_util::Limited::new(body, 1024);
+        let result = limited.collect().await;
+        assert!(result.is_err(), "body over the limit must be rejected");
+    }
+
+    #[tokio::test]
+    async fn within_limit_request_body_is_accepted_by_limited() {
+        let body = http_body_util::Full::new(Bytes::from(vec![0u8; 512]));
+        let limited = http_body_util::Limited::new(body, 1024);
+        let result = limited.collect().await;
+        assert!(result.is_ok(), "body within the limit must be accepted");
+    }
+
+    /// A response body that never yields a frame, used to exercise the
+    /// per-frame read timeout in `collect_body_with_limit`.
+    struct StalledBody;
+
+    impl hyper::body::Body for StalledBody {
+        type Data = Bytes;
+        type Error = std::convert::Infallible;
+
+        fn poll_frame(
+            self: std::pin::Pin<&mut Self>,
+            _cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<Option<std::result::Result<hyper::body::Frame<Self::Data>, Self::Error>>>
+        {
+            std::task::Poll::Pending
+        }
+    }
+
+    // Acceptance (2): a stalled upstream response body times out instead of
+    // pinning a permit + memory indefinitely, surfacing as a 504.
+    #[tokio::test]
+    async fn stalled_response_body_times_out() {
+        let result = collect_body_with_limit(StalledBody, 1024, Duration::from_millis(50)).await;
+        assert_eq!(result, Err(BodyCollectError::Timeout));
+        assert_eq!(
+            BodyCollectError::Timeout.status(),
+            StatusCode::GATEWAY_TIMEOUT
+        );
+    }
+
+    #[tokio::test]
+    async fn response_body_over_limit_is_rejected() {
+        let body = http_body_util::Full::new(Bytes::from(vec![0u8; 2048]));
+        let result = collect_body_with_limit(body, 1024, Duration::from_secs(5)).await;
+        assert_eq!(result, Err(BodyCollectError::TooLarge));
+        assert_eq!(BodyCollectError::TooLarge.status(), StatusCode::BAD_GATEWAY);
+    }
+
+    #[tokio::test]
+    async fn response_body_within_limit_is_collected() {
+        let body = http_body_util::Full::new(Bytes::from_static(b"hello"));
+        let result = collect_body_with_limit(body, 1024, Duration::from_secs(5)).await;
+        assert_eq!(result, Ok(Bytes::from_static(b"hello")));
     }
 }

--- a/ferrotunnel-http/src/ingress.rs
+++ b/ferrotunnel-http/src/ingress.rs
@@ -1,3 +1,4 @@
+use crate::accept_errors::is_transient_accept_error;
 use ferrotunnel_common::Result;
 use ferrotunnel_core::tunnel::session::SessionStoreBackend;
 use ferrotunnel_plugin::{PluginAction, PluginRegistry, RequestContext, ResponseContext};
@@ -92,7 +93,18 @@ impl HttpIngress {
         );
 
         loop {
-            let (stream, peer_addr) = listener.accept().await?;
+            let (stream, peer_addr) = match listener.accept().await {
+                Ok(connection) => connection,
+                Err(error) if is_transient_accept_error(&error) => {
+                    warn!(
+                        bind_addr = %self.addr,
+                        error = %error,
+                        "Transient HTTP ingress accept error; continuing"
+                    );
+                    continue;
+                }
+                Err(error) => return Err(error.into()),
+            };
 
             // Acquire connection permit (limit concurrent connections)
             let Ok(permit) = self.connection_semaphore.clone().try_acquire_owned() else {

--- a/ferrotunnel-http/src/lib.rs
+++ b/ferrotunnel-http/src/lib.rs
@@ -1,3 +1,5 @@
+mod accept_errors;
+
 #[cfg(feature = "http3")]
 pub mod http3_ingress;
 pub mod ingress;

--- a/ferrotunnel-http/src/tcp_ingress.rs
+++ b/ferrotunnel-http/src/tcp_ingress.rs
@@ -3,7 +3,7 @@
 //! Provides protocol-agnostic TCP forwarding through the tunnel.
 //! Useful for database connections, SSH, and custom protocols.
 
-use crate::accept_errors::is_transient_accept_error;
+use crate::accept_errors::{is_transient_accept_error, AcceptBackoff};
 use ferrotunnel_common::Result;
 use ferrotunnel_core::tunnel::session::SessionStoreBackend;
 use ferrotunnel_protocol::frame::Protocol;
@@ -73,15 +73,24 @@ impl TcpIngress {
         let listener = TcpListener::bind(self.addr).await?;
         info!("TCP Ingress listening on {}", self.addr);
 
+        let mut accept_backoff = AcceptBackoff::default();
         loop {
             let (stream, peer_addr) = match listener.accept().await {
-                Ok(connection) => connection,
+                Ok(connection) => {
+                    accept_backoff.reset();
+                    connection
+                }
                 Err(error) if is_transient_accept_error(&error) => {
-                    warn!(
-                        bind_addr = %self.addr,
-                        error = %error,
-                        "Transient TCP ingress accept error; continuing"
-                    );
+                    let (delay, should_log) = accept_backoff.record_failure();
+                    if should_log {
+                        warn!(
+                            bind_addr = %self.addr,
+                            error = %error,
+                            backoff_ms = delay.as_millis(),
+                            "Transient TCP ingress accept error; backing off"
+                        );
+                    }
+                    tokio::time::sleep(delay).await;
                     continue;
                 }
                 Err(error) => return Err(error.into()),

--- a/ferrotunnel-http/src/tcp_ingress.rs
+++ b/ferrotunnel-http/src/tcp_ingress.rs
@@ -3,6 +3,7 @@
 //! Provides protocol-agnostic TCP forwarding through the tunnel.
 //! Useful for database connections, SSH, and custom protocols.
 
+use crate::accept_errors::is_transient_accept_error;
 use ferrotunnel_common::Result;
 use ferrotunnel_core::tunnel::session::SessionStoreBackend;
 use ferrotunnel_protocol::frame::Protocol;
@@ -73,7 +74,18 @@ impl TcpIngress {
         info!("TCP Ingress listening on {}", self.addr);
 
         loop {
-            let (stream, peer_addr) = listener.accept().await?;
+            let (stream, peer_addr) = match listener.accept().await {
+                Ok(connection) => connection,
+                Err(error) if is_transient_accept_error(&error) => {
+                    warn!(
+                        bind_addr = %self.addr,
+                        error = %error,
+                        "Transient TCP ingress accept error; continuing"
+                    );
+                    continue;
+                }
+                Err(error) => return Err(error.into()),
+            };
 
             // CRITICAL: Set TCP_NODELAY to disable Nagle's algorithm for low latency
             if let Err(e) = stream.set_nodelay(true) {

--- a/ferrotunnel-observability/README.md
+++ b/ferrotunnel-observability/README.md
@@ -152,7 +152,9 @@ async fn main() {
 use axum::{routing::get, Router};
 use ferrotunnel_observability::gather_metrics;
 
-let app = Router::new().route("/metrics", get(|| async { gather_metrics() }));
+let app = Router::new().route("/metrics", get(|| async {
+    gather_metrics().unwrap_or_else(|_| "failed to gather metrics\n".to_string())
+}));
 ```
 
 ## Configuration

--- a/ferrotunnel-observability/src/dashboard/handlers.rs
+++ b/ferrotunnel-observability/src/dashboard/handlers.rs
@@ -145,13 +145,22 @@ pub async fn get_request_handler(
 ///
 /// GET /api/v1/metrics
 pub async fn metrics_handler() -> Response {
-    let metrics = crate::gather_metrics();
-    (
-        StatusCode::OK,
-        [("content-type", "text/plain; charset=utf-8")],
-        metrics,
-    )
-        .into_response()
+    match crate::gather_metrics() {
+        Ok(metrics) => (
+            StatusCode::OK,
+            [("content-type", "text/plain; charset=utf-8")],
+            metrics,
+        )
+            .into_response(),
+        Err(error) => {
+            tracing::error!(%error, "failed to gather dashboard metrics");
+            error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "METRICS_ERROR",
+                "Failed to gather metrics",
+            )
+        }
+    }
 }
 
 /// Replay a specific request.

--- a/ferrotunnel-observability/src/metrics.rs
+++ b/ferrotunnel-observability/src/metrics.rs
@@ -5,8 +5,10 @@
 //! - **Units**: in the name (e.g. `_seconds`, `_bytes`)
 //! - **Gauges**: descriptive names, no `_total`
 
+use anyhow::Context;
 use prometheus::{register_counter, register_gauge, register_histogram, Counter, Gauge, Histogram};
 use std::sync::LazyLock;
+use std::sync::Once;
 use std::sync::OnceLock;
 use std::time::Duration;
 
@@ -17,6 +19,7 @@ pub static REGISTRY: LazyLock<Registry> = LazyLock::new(Registry::new);
 
 /// Global tunnel metrics. Set when [`init_metrics`] is called.
 static TUNNEL_METRICS: OnceLock<TunnelMetrics> = OnceLock::new();
+static METRICS_INIT: Once = Once::new();
 
 /// Tunnel-level metrics: frames, bytes, decode/encode latency, queue depth.
 ///
@@ -33,43 +36,43 @@ pub struct TunnelMetrics {
 impl TunnelMetrics {
     /// Create and register metrics with the default Prometheus registry.
     pub fn new() -> Self {
+        Self::try_new().expect("register FerroTunnel tunnel metrics")
+    }
+
+    /// Try to create and register metrics with the default Prometheus registry.
+    pub fn try_new() -> Result<Self, prometheus::Error> {
         let frames_processed = register_counter!(
             "ferrotunnel_tunnel_frames_processed_total",
             "Total number of protocol frames processed (decoded or encoded)"
-        )
-        .expect("register ferrotunnel_tunnel_frames_processed_total");
+        )?;
 
         let bytes_transferred = register_counter!(
             "ferrotunnel_tunnel_bytes_transferred_total",
             "Total bytes transferred through the tunnel (data frames only)"
-        )
-        .expect("register ferrotunnel_tunnel_bytes_transferred_total");
+        )?;
 
         let decode_latency = register_histogram!(
             "ferrotunnel_tunnel_decode_latency_seconds",
             "Latency of decoding frames from the wire"
-        )
-        .expect("register ferrotunnel_tunnel_decode_latency_seconds");
+        )?;
 
         let encode_latency = register_histogram!(
             "ferrotunnel_tunnel_encode_latency_seconds",
             "Latency of encoding frames to the wire"
-        )
-        .expect("register ferrotunnel_tunnel_encode_latency_seconds");
+        )?;
 
         let queue_depth = register_gauge!(
             "ferrotunnel_tunnel_queue_depth",
             "Current number of frames queued in the batched sender"
-        )
-        .expect("register ferrotunnel_tunnel_queue_depth");
+        )?;
 
-        Self {
+        Ok(Self {
             frames_processed,
             bytes_transferred,
             decode_latency,
             encode_latency,
             queue_depth,
-        }
+        })
     }
 
     /// Record a decode operation (frames decoded, bytes, and latency).
@@ -116,8 +119,19 @@ pub fn tunnel_metrics() -> Option<&'static TunnelMetrics> {
 /// Initialize the metrics system and register tunnel metrics.
 pub fn init_metrics() {
     let _ = LazyLock::force(&REGISTRY);
-    let _ = TUNNEL_METRICS.set(TunnelMetrics::new());
-    tracing::info!("Metrics infrastructure initialized");
+    if TUNNEL_METRICS.get().is_some() {
+        return;
+    }
+
+    METRICS_INIT.call_once(|| match TunnelMetrics::try_new() {
+        Ok(metrics) => {
+            let _ = TUNNEL_METRICS.set(metrics);
+            tracing::info!("Metrics infrastructure initialized");
+        }
+        Err(error) => {
+            tracing::error!(%error, "failed to initialize metrics infrastructure");
+        }
+    });
 }
 
 /// Returns true if metrics have been initialized.
@@ -127,11 +141,29 @@ pub fn metrics_enabled() -> bool {
 }
 
 /// Gather all metrics into Prometheus text format.
-pub fn gather_metrics() -> String {
+pub fn gather_metrics() -> anyhow::Result<String> {
     use prometheus::Encoder;
     let encoder = prometheus::TextEncoder::new();
     let metric_families = prometheus::gather();
     let mut buffer = Vec::new();
-    encoder.encode(&metric_families, &mut buffer).unwrap();
-    String::from_utf8(buffer).unwrap()
+    encoder
+        .encode(&metric_families, &mut buffer)
+        .context("failed to encode Prometheus metrics")?;
+    String::from_utf8(buffer).context("Prometheus metrics output was not valid UTF-8")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{gather_metrics, init_metrics, metrics_enabled};
+
+    #[test]
+    fn init_metrics_is_idempotent_and_scrape_does_not_panic() {
+        init_metrics();
+        init_metrics();
+
+        assert!(metrics_enabled());
+        let metrics = gather_metrics().expect("metrics scrape should succeed");
+
+        assert!(metrics.contains("ferrotunnel_tunnel_frames_processed_total"));
+    }
 }

--- a/ferrotunnel-plugin/src/registry.rs
+++ b/ferrotunnel-plugin/src/registry.rs
@@ -1,6 +1,12 @@
 use crate::traits::{Plugin, PluginAction, RequestContext, ResponseContext};
+use std::error::Error;
+use std::io;
 use std::sync::Arc;
 use tokio::sync::RwLock;
+use tokio::task::JoinError;
+
+type PluginError = Box<dyn Error + Send + Sync + 'static>;
+type PluginResult<T> = Result<T, PluginError>;
 
 /// Registry manages all loaded plugins
 #[derive(Default)]
@@ -21,7 +27,7 @@ impl PluginRegistry {
     }
 
     /// Initialize all plugins
-    pub async fn init_all(&self) -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+    pub async fn init_all(&self) -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
         for plugin_lock in &self.plugins {
             let mut plugin = plugin_lock.write().await;
             tracing::info!("Initializing plugin: {}", plugin.name());
@@ -35,14 +41,28 @@ impl PluginRegistry {
         &self,
         req: &mut http::Request<()>,
         ctx: &RequestContext,
-    ) -> Result<PluginAction, Box<dyn std::error::Error + Send + Sync + 'static>> {
+    ) -> Result<PluginAction, Box<dyn Error + Send + Sync + 'static>> {
+        let mut current_req = std::mem::replace(req, http::Request::new(()));
         for plugin_lock in &self.plugins {
-            let plugin = plugin_lock.read().await;
-            match plugin.on_request(req, ctx).await? {
+            let plugin_name = plugin_name(plugin_lock).await;
+            let plugin_lock = plugin_lock.clone();
+            let ctx = ctx.clone();
+            let hook = tokio::spawn(run_request_hook(plugin_lock, current_req, ctx));
+            let (next_req, action) = match hook.await {
+                Ok(result) => result,
+                Err(err) => return Err(join_error(&plugin_name, "on_request", &err)),
+            };
+            current_req = next_req;
+
+            match action? {
                 PluginAction::Continue => continue,
-                action => return Ok(action), // Short-circuit on non-Continue
+                action => {
+                    *req = current_req;
+                    return Ok(action); // Short-circuit on non-Continue
+                }
             }
         }
+        *req = current_req;
         Ok(PluginAction::Continue)
     }
 
@@ -51,21 +71,33 @@ impl PluginRegistry {
         &self,
         res: &mut http::Response<Vec<u8>>,
         ctx: &ResponseContext,
-    ) -> Result<PluginAction, Box<dyn std::error::Error + Send + Sync + 'static>> {
+    ) -> Result<PluginAction, Box<dyn Error + Send + Sync + 'static>> {
+        let mut current_res = std::mem::replace(res, http::Response::new(Vec::new()));
         for plugin_lock in &self.plugins {
-            let plugin = plugin_lock.read().await;
-            match plugin.on_response(res, ctx).await? {
+            let plugin_name = plugin_name(plugin_lock).await;
+            let plugin_lock = plugin_lock.clone();
+            let ctx = ctx.clone();
+            let hook = tokio::spawn(run_response_hook(plugin_lock, current_res, ctx));
+            let (next_res, action) = match hook.await {
+                Ok(result) => result,
+                Err(err) => return Err(join_error(&plugin_name, "on_response", &err)),
+            };
+            current_res = next_res;
+
+            match action? {
                 PluginAction::Continue => continue,
-                action => return Ok(action),
+                action => {
+                    *res = current_res;
+                    return Ok(action);
+                }
             }
         }
+        *res = current_res;
         Ok(PluginAction::Continue)
     }
 
     /// Shutdown all plugins
-    pub async fn shutdown_all(
-        &self,
-    ) -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+    pub async fn shutdown_all(&self) -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
         for plugin_lock in &self.plugins {
             let mut plugin = plugin_lock.write().await;
             tracing::info!("Shutting down plugin: {}", plugin.name());
@@ -92,6 +124,45 @@ impl PluginRegistry {
     }
 }
 
+async fn plugin_name(plugin_lock: &Arc<RwLock<dyn Plugin>>) -> String {
+    let plugin = plugin_lock.read().await;
+    plugin.name().to_owned()
+}
+
+async fn run_request_hook(
+    plugin_lock: Arc<RwLock<dyn Plugin>>,
+    mut req: http::Request<()>,
+    ctx: RequestContext,
+) -> (http::Request<()>, PluginResult<PluginAction>) {
+    let plugin = plugin_lock.read().await;
+    let action = plugin.on_request(&mut req, &ctx).await;
+    (req, action)
+}
+
+async fn run_response_hook(
+    plugin_lock: Arc<RwLock<dyn Plugin>>,
+    mut res: http::Response<Vec<u8>>,
+    ctx: ResponseContext,
+) -> (http::Response<Vec<u8>>, PluginResult<PluginAction>) {
+    let plugin = plugin_lock.read().await;
+    let action = plugin.on_response(&mut res, &ctx).await;
+    (res, action)
+}
+
+fn join_error(plugin_name: &str, hook: &str, err: &JoinError) -> PluginError {
+    if err.is_panic() {
+        tracing::error!(plugin = plugin_name, hook, "plugin hook panicked");
+        Box::new(io::Error::other(format!(
+            "plugin `{plugin_name}` panicked during {hook} hook"
+        )))
+    } else {
+        tracing::error!(plugin = plugin_name, hook, error = %err, "plugin hook task failed");
+        Box::new(io::Error::other(format!(
+            "plugin `{plugin_name}` {hook} hook task failed: {err}"
+        )))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -109,7 +180,7 @@ mod tests {
             &self,
             _req: &mut http::Request<()>,
             _ctx: &RequestContext,
-        ) -> Result<PluginAction, Box<dyn std::error::Error + Send + Sync + 'static>> {
+        ) -> Result<PluginAction, Box<dyn Error + Send + Sync + 'static>> {
             Ok(PluginAction::Reject {
                 status: 403,
                 reason: "Blocked".into(),
@@ -139,12 +210,53 @@ mod tests {
         }
     }
 
+    struct PanicRequestPlugin;
+    #[async_trait]
+    impl Plugin for PanicRequestPlugin {
+        fn name(&self) -> &str {
+            "panic-request"
+        }
+
+        async fn on_request(
+            &self,
+            _req: &mut http::Request<()>,
+            _ctx: &RequestContext,
+        ) -> Result<PluginAction, Box<dyn Error + Send + Sync + 'static>> {
+            panic!("request hook panic")
+        }
+    }
+
+    struct PanicResponsePlugin;
+    #[async_trait]
+    impl Plugin for PanicResponsePlugin {
+        fn name(&self) -> &str {
+            "panic-response"
+        }
+
+        async fn on_response(
+            &self,
+            _res: &mut http::Response<Vec<u8>>,
+            _ctx: &ResponseContext,
+        ) -> Result<PluginAction, Box<dyn Error + Send + Sync + 'static>> {
+            panic!("response hook panic")
+        }
+    }
+
     fn make_request_ctx() -> RequestContext {
         RequestContext {
             tunnel_id: "test".into(),
             session_id: "sess".into(),
             remote_addr: "127.0.0.1:80".parse().unwrap(),
             timestamp: std::time::SystemTime::now(),
+        }
+    }
+
+    fn make_response_ctx() -> ResponseContext {
+        ResponseContext {
+            tunnel_id: "test".into(),
+            session_id: "sess".into(),
+            status_code: 200,
+            duration_ms: 1,
         }
     }
 
@@ -258,5 +370,53 @@ mod tests {
             PluginAction::Reject { status, .. } => assert_eq!(status, 403),
             _ => panic!("Expected reject - should short-circuit"),
         }
+    }
+
+    #[tokio::test]
+    async fn test_request_hook_panic_is_reported_as_error() {
+        let mut registry = PluginRegistry::new();
+        registry.register(Arc::new(RwLock::new(PanicRequestPlugin)));
+
+        let join = tokio::spawn(async move {
+            let mut req = http::Request::new(());
+            let ctx = make_request_ctx();
+            registry.execute_request_hooks(&mut req, &ctx).await
+        });
+
+        let result = match join.await {
+            Ok(result) => result,
+            Err(err) => panic!("registry task should not panic: {err}"),
+        };
+        let err = match result {
+            Ok(action) => panic!("expected plugin error, got {action:?}"),
+            Err(err) => err,
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("panic-request"));
+        assert!(msg.contains("on_request"));
+    }
+
+    #[tokio::test]
+    async fn test_response_hook_panic_is_reported_as_error() {
+        let mut registry = PluginRegistry::new();
+        registry.register(Arc::new(RwLock::new(PanicResponsePlugin)));
+
+        let join = tokio::spawn(async move {
+            let mut res = http::Response::new(Vec::new());
+            let ctx = make_response_ctx();
+            registry.execute_response_hooks(&mut res, &ctx).await
+        });
+
+        let result = match join.await {
+            Ok(result) => result,
+            Err(err) => panic!("registry task should not panic: {err}"),
+        };
+        let err = match result {
+            Ok(action) => panic!("expected plugin error, got {action:?}"),
+            Err(err) => err,
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("panic-response"));
+        assert!(msg.contains("on_response"));
     }
 }

--- a/ferrotunnel-plugin/src/registry.rs
+++ b/ferrotunnel-plugin/src/registry.rs
@@ -402,12 +402,14 @@ mod tests {
         registry.register(Arc::new(RwLock::new(PanicResponsePlugin)));
 
         let join = tokio::spawn(async move {
-            let mut res = http::Response::new(Vec::new());
+            // Start from a real upstream response body to prove the contract below.
+            let mut res = http::Response::new(b"real-upstream-body".to_vec());
             let ctx = make_response_ctx();
-            registry.execute_response_hooks(&mut res, &ctx).await
+            let outcome = registry.execute_response_hooks(&mut res, &ctx).await;
+            (outcome, res)
         });
 
-        let result = match join.await {
+        let (result, res) = match join.await {
             Ok(result) => result,
             Err(err) => panic!("registry task should not panic: {err}"),
         };
@@ -418,5 +420,13 @@ mod tests {
         let msg = err.to_string();
         assert!(msg.contains("panic-response"));
         assert!(msg.contains("on_response"));
+        // Contract relied on by the HTTP ingress (#138): on a hook error the
+        // response was moved into the panicked task, so `res` is left as the
+        // empty placeholder. Callers MUST return a clean 500 instead of shipping
+        // `res`, never the original upstream body.
+        assert!(
+            res.body().is_empty(),
+            "panicked response hook must leave the response emptied, not forward it"
+        );
     }
 }

--- a/ferrotunnel-plugin/src/traits.rs
+++ b/ferrotunnel-plugin/src/traits.rs
@@ -56,6 +56,12 @@ pub enum StreamDirection {
 }
 
 /// Core plugin trait
+///
+/// Hook implementations should return `Err` for recoverable failures and avoid
+/// panicking. `PluginRegistry` isolates `on_request` and `on_response` panics,
+/// logs the offending plugin name, and converts the panic into a normal plugin
+/// error so ingress handlers can return a clean 500 response instead of dropping
+/// the connection task.
 #[async_trait]
 pub trait Plugin: Send + Sync {
     /// Plugin name (for logging/debugging)

--- a/ferrotunnel/src/server.rs
+++ b/ferrotunnel/src/server.rs
@@ -121,12 +121,14 @@ impl Server {
                 .ok()
         });
 
-        let mut ingress =
-            HttpIngress::new(config.http_bind_addr, sessions.clone(), registry.clone());
+        let ingress = HttpIngress::new(config.http_bind_addr, sessions.clone(), registry.clone());
+        // Shadow (rather than `mut`) so the binding stays immutable when the
+        // `http3` feature is disabled and `alt_svc_header` does not exist.
         #[cfg(feature = "http3")]
-        if let Some(value) = alt_svc_header {
-            ingress = ingress.with_alt_svc_header(value);
-        }
+        let ingress = match alt_svc_header {
+            Some(value) => ingress.with_alt_svc_header(value),
+            None => ingress,
+        };
 
         // Spawn both services
         #[cfg(feature = "quic")]


### PR DESCRIPTION
## Release 1.2.0

Hardening release closing the **v1.2.0 audit milestone** (all 8 issues). Every fix lands on `release/1.2.0` with unit/integration tests; `cargo fmt`, `clippy -D warnings` (default + `quic`), and the full workspace test suite are green.

### Resilience — accept loops & shutdown
- **#131** — Survive transient `accept()` errors in HTTP/TCP ingress (classify retryable kinds: `EINTR`/`WouldBlock`/`ConnectionAborted`/`ConnectionReset`/`EMFILE`/`ENFILE`; fatal errors still propagate).
- **Accept-loop backoff (ingress)** — follow-up to #131: the transient-retry path now backs off (5ms→1s exponential w/ jitter) with rate-limited logging instead of busy-spinning a core on persistent `EMFILE`.
- **#130** — Same backoff applied to the **core** server TLS/TCP and QUIC accept loops (reuses `reconnect::Backoff`). Because `transport::accept` performs the per-connection TLS/QUIC handshake inline, per-connection handshake failures (e.g. a plain-TCP health probe against a TLS listener) log + back off and **never terminate the accept loop** — preserving pre-1.2.0 survive-all-errors behavior.
- **#135** — Track the session-cleanup `JoinHandle` and abort it on shutdown; guarantees a single cleanup loop per server instance (no Arc-retention leak / no racing loops when `run()` + `run_quic()` both run).

### Robustness — no panics, no hangs
- **#137** — `init_metrics()` is now idempotent (guarded `Once` + fallible `try_new`) and `gather_metrics()` returns `Result`; `/metrics` and the dashboard return HTTP 500 on scrape failure instead of panicking the serving task.
- **#138** — Plugin `on_request`/`on_response` hooks run in isolated tasks; a third-party plugin panic becomes a logged plugin error → clean 500 instead of a dropped connection. Panic contract documented on the `Plugin` trait.
- **#136** — All `frame_tx` sends use a send timeout / fail-fast on a full-or-closed channel, so `VirtualStream::poll_write` and heartbeat sends can no longer block indefinitely under network partition.

### Security — resource bounds & rate limiting
- **#132** — Bound and time-limit H1/H2 ingress bodies: add `max_request_body_size` (`http_body_util::Limited`, oversized → 413) and a per-frame read timeout on response-body collection (stalled upstream → 504), mirroring the H3 ingress.
- **#119** — Per-session rate limiter is now actually enforced: instantiated per session, `check_stream_open()` denies excess stream opens, and `check_data(bytes)` accounts for real payload size via governor `check_n` (previously dead code consuming one token regardless of size).

### Validation
- `cargo fmt --all --check` ✅
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` ✅ and `--features quic` ✅
- `cargo test --workspace --all-features` ✅

Closes #119, #130, #131, #132, #135, #136, #137, #138.
