### PR TITLE
Release/1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-06-26
+
+Bug-fix and reliability release closing the v1.3.0 milestone.
+
+### Fixed
+
+- Supervise the server lifecycle task so `is_running()`, `shutdown()`, and the double-start guard work ([#120](https://github.com/ferro-labs/ferrotunnel/issues/120)).
+- Bound `Client::start()` with a configurable `startup_timeout` so it no longer hangs on initial connection failure under auto-reconnect ([#117](https://github.com/ferro-labs/ferrotunnel/issues/117)).
+- Make duplicate `tunnel_id` registration atomic, closing a TOCTOU race ([#118](https://github.com/ferro-labs/ferrotunnel/issues/118)).
+- Spawn TCP virtual-stream handlers concurrently instead of serializing multiplexed streams ([#129](https://github.com/ferro-labs/ferrotunnel/issues/129)).
+- Don't hold the HTTP/2 connection-pool mutex across connect/handshake ([#133](https://github.com/ferro-labs/ferrotunnel/issues/133)).
+- Reuse the shared connection pool for gRPC streams instead of one pool per stream ([#134](https://github.com/ferro-labs/ferrotunnel/issues/134)).
+- Ingress: return 413 for chunked oversized request bodies and apply a per-frame timeout on the streaming response path ([#159](https://github.com/ferro-labs/ferrotunnel/issues/159)).
+
 ## [1.2.0] - 2026-06-19
 
 Hardening release closing the v1.2.0 audit milestone.
@@ -294,7 +308,8 @@ FerroTunnel v1.0.0 is the first stable release.
 | `ferrotunnel-observability` | Metrics, tracing, and dashboard |
 | `ferrotunnel-common` | Shared types and errors |
 
-[Unreleased]: https://github.com/ferro-labs/ferrotunnel/compare/v1.2.0...HEAD
+[Unreleased]: https://github.com/ferro-labs/ferrotunnel/compare/v1.3.0...HEAD
+[1.3.0]: https://github.com/ferro-labs/ferrotunnel/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/ferro-labs/ferrotunnel/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/ferro-labs/ferrotunnel/compare/v1.0.8...v1.1.0
 [1.0.8]: https://github.com/ferro-labs/ferrotunnel/compare/v1.0.7...v1.0.8

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.2.0"
+version = "1.3.0"
 edition = "2021"
 rust-version = "1.91"
 authors = ["Mitul Shah <hello@ferrolabs.ai>"]
@@ -53,7 +53,7 @@ tokio = { version = "1", features = ["full"] }
 
 # Logging
 tracing = "0.1"
-ferrotunnel-observability = { version = "1.2.0", path = "ferrotunnel-observability" }
+ferrotunnel-observability = { version = "1.3.0", path = "ferrotunnel-observability" }
 
 # QUIC transport
 quinn = { version = "0.11", default-features = false, features = ["runtime-tokio", "rustls-ring"] }

--- a/README.md
+++ b/README.md
@@ -238,7 +238,9 @@ async fn main() -> ferrotunnel::Result<()> {
         .token("my-secret-token")
         .build()?;
 
-    server.start().await
+    server.start().await?;
+    tokio::signal::ctrl_c().await?;
+    server.shutdown().await
 }
 ```
 

--- a/ferrotunnel-cli/Cargo.toml
+++ b/ferrotunnel-cli/Cargo.toml
@@ -17,12 +17,12 @@ doc = false
 
 [dependencies]
 # Core functionality
-ferrotunnel-core = { version = "1.2.0", path = "../ferrotunnel-core", features = [
+ferrotunnel-core = { version = "1.3.0", path = "../ferrotunnel-core", features = [
     "metrics",
 ] }
-ferrotunnel-http = { version = "1.2.0", path = "../ferrotunnel-http" }
-ferrotunnel-protocol = { version = "1.2.0", path = "../ferrotunnel-protocol" }
-ferrotunnel-plugin = { version = "1.2.0", path = "../ferrotunnel-plugin" }
+ferrotunnel-http = { version = "1.3.0", path = "../ferrotunnel-http" }
+ferrotunnel-protocol = { version = "1.3.0", path = "../ferrotunnel-protocol" }
+ferrotunnel-plugin = { version = "1.3.0", path = "../ferrotunnel-plugin" }
 ferrotunnel-observability = { workspace = true, features = [
     "dashboard",
     "axum",

--- a/ferrotunnel-core/Cargo.toml
+++ b/ferrotunnel-core/Cargo.toml
@@ -12,8 +12,8 @@ keywords = ["tunnel", "networking", "async", "core"]
 categories = ["network-programming", "asynchronous"]
 
 [dependencies]
-ferrotunnel-common = { version = "1.2.0", path = "../ferrotunnel-common" }
-ferrotunnel-protocol = { version = "1.2.0", path = "../ferrotunnel-protocol" }
+ferrotunnel-common = { version = "1.3.0", path = "../ferrotunnel-common" }
+ferrotunnel-protocol = { version = "1.3.0", path = "../ferrotunnel-protocol" }
 
 tokio = { workspace = true }
 tokio-util = { workspace = true }
@@ -54,7 +54,7 @@ crossbeam-queue = "0.3"
 quinn = { workspace = true, optional = true }
 
 # Optional metrics (decode/encode latency, queue depth)
-ferrotunnel-observability = { version = "1.2.0", path = "../ferrotunnel-observability", optional = true }
+ferrotunnel-observability = { version = "1.3.0", path = "../ferrotunnel-observability", optional = true }
 
 # File descriptor exhaustion (EMFILE/ENFILE) detection in accept-loop backoff
 [target.'cfg(unix)'.dependencies]

--- a/ferrotunnel-core/src/stream/multiplexer.rs
+++ b/ferrotunnel-core/src/stream/multiplexer.rs
@@ -661,4 +661,67 @@ mod tests {
             "write to a full frame_tx must time out rather than hang"
         );
     }
+
+    /// Issue #129: a slow virtual-stream handler must not block a fast one.
+    ///
+    /// Two streams are opened through the real control path (stream A first,
+    /// then B). The TCP dispatch loop spawns each handler, so the fast stream
+    /// B completes before the slow stream A even though A was opened first.
+    /// Under the old serial `stream_handler(s).await` loop, B would be stuck
+    /// behind A's sleep and this assertion would fail (or time out).
+    ///
+    /// `start_paused` lets tokio auto-advance virtual time past A's sleep
+    /// without waiting wall-clock.
+    #[tokio::test(start_paused = true)]
+    async fn slow_stream_does_not_block_concurrent_stream() {
+        use crate::tunnel::client::spawn_stream_dispatch_loop;
+
+        const STREAM_A: u32 = 2;
+        const STREAM_B: u32 = 4;
+        const SLOW_DELAY: Duration = Duration::from_secs(10);
+
+        let (frame_tx, _frame_rx) = bounded_async::<PrioritizedFrame>(64);
+        let (mux, new_stream_rx) = Multiplexer::new(frame_tx, false);
+
+        let (order_tx, mut order_rx) = tokio::sync::mpsc::unbounded_channel::<u32>();
+
+        // Fire-and-forget dispatch: A sleeps before recording, B records now.
+        spawn_stream_dispatch_loop(new_stream_rx, move |stream: VirtualStream| {
+            let order_tx = order_tx.clone();
+            let id = stream.id();
+            async move {
+                if id == STREAM_A {
+                    tokio::time::sleep(SLOW_DELAY).await;
+                }
+                let _ = order_tx.send(id);
+            }
+        });
+
+        // Push the slow stream first, then the fast stream, via process_frame.
+        for stream_id in [STREAM_A, STREAM_B] {
+            mux.process_frame(Frame::OpenStream(Box::new(OpenStreamFrame {
+                stream_id,
+                protocol: Protocol::TCP,
+                headers: vec![],
+                body_hint: None,
+                priority: StreamPriority::default(),
+            })))
+            .await
+            .expect("process_frame queues the new stream");
+        }
+
+        // B must complete before A despite being opened second. The bounded
+        // timeout fails fast if the dispatch loop serializes handlers.
+        let first = timeout(Duration::from_secs(30), order_rx.recv())
+            .await
+            .expect("first completion within timeout")
+            .expect("order channel stays open");
+        let second = timeout(Duration::from_secs(30), order_rx.recv())
+            .await
+            .expect("second completion within timeout")
+            .expect("order channel stays open");
+
+        assert_eq!(first, STREAM_B, "fast stream B must complete first");
+        assert_eq!(second, STREAM_A, "slow stream A must complete last");
+    }
 }

--- a/ferrotunnel-core/src/tunnel/client.rs
+++ b/ferrotunnel-core/src/tunnel/client.rs
@@ -8,7 +8,7 @@ use ferrotunnel_protocol::codec::TunnelCodec;
 use ferrotunnel_protocol::constants::{MAX_PROTOCOL_VERSION, MIN_PROTOCOL_VERSION};
 use ferrotunnel_protocol::frame::{Frame, HandshakeFrame, HandshakeStatus};
 use futures::{SinkExt, StreamExt};
-use kanal::bounded_async;
+use kanal::{bounded_async, AsyncReceiver};
 use std::future::Future;
 use std::time::{Duration, Instant};
 use tokio::time::interval;
@@ -359,6 +359,30 @@ impl TunnelClient {
     }
 }
 
+/// Spawn the background loop that dispatches each accepted virtual stream to
+/// `stream_handler`.
+///
+/// Each handler is `tokio::spawn`ed (fire-and-forget) so a slow stream cannot
+/// block dispatch of the next one. The loop previously awaited each handler
+/// inline, which serialized all multiplexed TCP streams and — via
+/// `new_stream_rx` backpressure — stalled the frame loop and starved
+/// heartbeats. This mirrors the QUIC accept loop (`quic_stream_accept_loop`).
+/// See issue #129.
+pub(crate) fn spawn_stream_dispatch_loop<F, Fut>(
+    new_stream_rx: AsyncReceiver<VirtualStream>,
+    stream_handler: F,
+) where
+    F: Fn(VirtualStream) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = ()> + Send + 'static,
+{
+    tokio::spawn(async move {
+        while let Ok(s) = new_stream_rx.recv().await {
+            // #129: spawn each handler so a slow stream doesn't block the next.
+            tokio::spawn(stream_handler(s));
+        }
+    });
+}
+
 impl TunnelClient {
     async fn handshake<C>(
         framed: &mut Framed<transport::BoxedStream, TunnelCodec>,
@@ -437,11 +461,7 @@ impl TunnelClient {
         tokio::spawn(run_batched_sender(frame_rx, write_half, parts.codec));
 
         let (multiplexer, new_stream_rx) = Multiplexer::new(frame_tx, true);
-        tokio::spawn(async move {
-            while let Ok(s) = new_stream_rx.recv().await {
-                stream_handler(s).await;
-            }
-        });
+        spawn_stream_dispatch_loop(new_stream_rx, stream_handler);
 
         (multiplexer, split_stream)
     }

--- a/ferrotunnel-core/src/tunnel/session.rs
+++ b/ferrotunnel-core/src/tunnel/session.rs
@@ -1,5 +1,6 @@
 use crate::rate_limit::{RateLimiterConfig, SessionRateLimiter};
 use crate::stream::AnyMultiplexer;
+use dashmap::mapref::entry::Entry;
 use dashmap::DashMap;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
@@ -95,17 +96,22 @@ impl SessionStore {
     /// Add a new session.
     /// Returns error if `tunnel_id` is already registered by a different session.
     pub fn add(&self, session: Session) -> Result<(), SessionStoreError> {
-        let tunnel_id = session.tunnel_id.clone();
         let session_id = session.id;
 
-        // Check if tunnel_id already exists and belongs to a different session
-        if let Some(existing_id) = self.tunnel_index.get(&tunnel_id) {
-            if *existing_id != session_id {
-                return Err(SessionStoreError::TunnelIdAlreadyExists(tunnel_id));
+        // Atomically claim the tunnel_id via the entry API to avoid a TOCTOU race
+        // between the existence check and insertion (issue #118).
+        match self.tunnel_index.entry(session.tunnel_id.clone()) {
+            Entry::Occupied(entry) => {
+                if *entry.get() != session_id {
+                    return Err(SessionStoreError::TunnelIdAlreadyExists(
+                        entry.key().clone(),
+                    ));
+                }
+            }
+            Entry::Vacant(entry) => {
+                entry.insert(session_id);
             }
         }
-
-        self.tunnel_index.insert(tunnel_id, session_id);
         self.sessions.insert(session_id, session);
         Ok(())
     }
@@ -239,17 +245,24 @@ impl ShardedSessionStore {
 
     /// Add a new session. Returns error if `tunnel_id` is already registered by a different session.
     pub fn add(&self, session: Session) -> Result<(), SessionStoreError> {
-        let tunnel_id = session.tunnel_id.clone();
         let session_id = session.id;
-        let idx = shard_index(&tunnel_id, self.n_shards);
+        let idx = shard_index(&session.tunnel_id, self.n_shards);
         let (tunnel_index, sessions) = &self.shards[idx];
 
-        if let Some(existing_id) = tunnel_index.get(&tunnel_id) {
-            if *existing_id != session_id {
-                return Err(SessionStoreError::TunnelIdAlreadyExists(tunnel_id));
+        // Atomically claim the tunnel_id on the selected shard via the entry API
+        // to avoid a TOCTOU race between the existence check and insertion (issue #118).
+        match tunnel_index.entry(session.tunnel_id.clone()) {
+            Entry::Occupied(entry) => {
+                if *entry.get() != session_id {
+                    return Err(SessionStoreError::TunnelIdAlreadyExists(
+                        entry.key().clone(),
+                    ));
+                }
+            }
+            Entry::Vacant(entry) => {
+                entry.insert(session_id);
             }
         }
-        tunnel_index.insert(tunnel_id, session_id);
         sessions.insert(session_id, session);
         Ok(())
     }
@@ -555,5 +568,93 @@ mod tests {
         store.remove(&id);
         assert_eq!(store.count(), 0);
         assert!(store.get_by_tunnel_id("shard-tunnel").is_none());
+    }
+
+    /// Number of concurrent handshakes racing on the same tunnel_id.
+    const RACE_THREADS: usize = 32;
+
+    #[test]
+    fn test_concurrent_add_same_tunnel_id_no_orphan() {
+        use std::sync::{Arc, Barrier};
+        use std::thread;
+
+        let store = SessionStore::new();
+        let addr = "127.0.0.1:1234".parse().unwrap();
+        let barrier = Arc::new(Barrier::new(RACE_THREADS));
+
+        let handles: Vec<_> = (0..RACE_THREADS)
+            .map(|_| {
+                let store = store.clone();
+                let barrier = Arc::clone(&barrier);
+                thread::spawn(move || {
+                    let session = Session::new(
+                        Uuid::new_v4(),
+                        "race-tunnel".into(),
+                        addr,
+                        "token".into(),
+                        vec![],
+                        None,
+                    );
+                    // Release all threads simultaneously to force a true race.
+                    barrier.wait();
+                    store.add(session)
+                })
+            })
+            .collect();
+
+        let mut ok = 0usize;
+        let mut conflicts = 0usize;
+        for handle in handles {
+            match handle.join().expect("thread panicked") {
+                Ok(()) => ok += 1,
+                Err(SessionStoreError::TunnelIdAlreadyExists(_)) => conflicts += 1,
+            }
+        }
+
+        assert_eq!(ok, 1, "exactly one registration should succeed");
+        assert_eq!(conflicts, RACE_THREADS - 1, "all others must conflict");
+        assert_eq!(store.count(), 1, "no orphaned session should remain");
+    }
+
+    #[test]
+    fn test_sharded_concurrent_add_same_tunnel_id_no_orphan() {
+        use std::sync::{Arc, Barrier};
+        use std::thread;
+
+        let store = ShardedSessionStore::with_shards(4);
+        let addr = "127.0.0.1:1234".parse().unwrap();
+        let barrier = Arc::new(Barrier::new(RACE_THREADS));
+
+        let handles: Vec<_> = (0..RACE_THREADS)
+            .map(|_| {
+                let store = store.clone();
+                let barrier = Arc::clone(&barrier);
+                thread::spawn(move || {
+                    let session = Session::new(
+                        Uuid::new_v4(),
+                        "race-tunnel".into(),
+                        addr,
+                        "token".into(),
+                        vec![],
+                        None,
+                    );
+                    barrier.wait();
+                    store.add(session)
+                })
+            })
+            .collect();
+
+        let mut ok = 0usize;
+        let mut conflicts = 0usize;
+        for handle in handles {
+            match handle.join().expect("thread panicked") {
+                Ok(()) => ok += 1,
+                Err(SessionStoreError::TunnelIdAlreadyExists(_)) => conflicts += 1,
+            }
+        }
+
+        assert_eq!(ok, 1, "exactly one registration should succeed");
+        assert_eq!(conflicts, RACE_THREADS - 1, "all others must conflict");
+        assert_eq!(store.count(), 1, "no orphaned session should remain");
     }
 }

--- a/ferrotunnel-http/Cargo.toml
+++ b/ferrotunnel-http/Cargo.toml
@@ -12,10 +12,10 @@ categories = ["network-programming", "web-programming"]
 description = "HTTP ingress and proxy implementation for FerroTunnel"
 
 [dependencies]
-ferrotunnel-core = { version = "1.2.0", path = "../ferrotunnel-core" }
-ferrotunnel-protocol = { version = "1.2.0", path = "../ferrotunnel-protocol" }
-ferrotunnel-plugin = { version = "1.2.0", path = "../ferrotunnel-plugin" }
-ferrotunnel-common = { version = "1.2.0", path = "../ferrotunnel-common" }
+ferrotunnel-core = { version = "1.3.0", path = "../ferrotunnel-core" }
+ferrotunnel-protocol = { version = "1.3.0", path = "../ferrotunnel-protocol" }
+ferrotunnel-plugin = { version = "1.3.0", path = "../ferrotunnel-plugin" }
+ferrotunnel-common = { version = "1.3.0", path = "../ferrotunnel-common" }
 tokio = { workspace = true }
 hyper = { version = "1", features = ["full", "http2"] }
 http-body-util = "0.1"
@@ -28,7 +28,7 @@ futures = "0.3"
 tower = { version = "0.5", features = ["full"] }
 tower-service = "0.3"
 thiserror = { workspace = true }
-ferrotunnel-observability = { version = "1.2.0", path = "../ferrotunnel-observability", optional = true }
+ferrotunnel-observability = { version = "1.3.0", path = "../ferrotunnel-observability", optional = true }
 h3 = { workspace = true, optional = true }
 h3-quinn = { workspace = true, optional = true }
 quinn = { workspace = true, optional = true }

--- a/ferrotunnel-http/Cargo.toml
+++ b/ferrotunnel-http/Cargo.toml
@@ -34,6 +34,9 @@ h3-quinn = { workspace = true, optional = true }
 quinn = { workspace = true, optional = true }
 rustls = { version = "0.23", optional = true, default-features = false, features = ["ring"] }
 
+[dev-dependencies]
+kanal = "0.1"
+
 [features]
 http3 = ["dep:h3", "dep:h3-quinn", "dep:quinn", "dep:rustls"]
 quic = ["ferrotunnel-core/quic"]

--- a/ferrotunnel-http/src/ingress.rs
+++ b/ferrotunnel-http/src/ingress.rs
@@ -10,8 +10,12 @@ use hyper::service::service_fn;
 use hyper::{Request, Response, StatusCode};
 use hyper_util::rt::{TokioExecutor, TokioIo};
 use hyper_util::server::conn::auto::Builder as AutoBuilder;
+use std::future::Future;
 use std::net::SocketAddr;
+use std::pin::Pin;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::task::{Context, Poll};
 use std::time::{Duration, SystemTime};
 use tokio::net::TcpListener;
 use tokio::sync::Semaphore;
@@ -55,7 +59,11 @@ pub struct HttpIngress {
     connection_semaphore: Arc<Semaphore>,
 }
 
-type BoxBody = http_body_util::combinators::BoxBody<Bytes, hyper::Error>;
+/// Boxed error type for custom body wrappers. `hyper::Error` has no public
+/// constructor, so wrappers that emit their own errors (oversized request body,
+/// stalled response body) widen the body error type to this trait object.
+type BoxError = Box<dyn std::error::Error + Send + Sync>;
+type BoxBody = http_body_util::combinators::BoxBody<Bytes, BoxError>;
 
 impl HttpIngress {
     pub fn new(
@@ -285,7 +293,17 @@ async fn handle_request(
         ));
     }
 
-    let limited_body = http_body_util::Limited::new(body, config.max_request_body_size).boxed();
+    // Shared flag flipped by `LimitedBody` the moment a frame pushes the request
+    // body past the cap. Declared before the is_grpc split so both the gRPC and
+    // HTTP/1 upstream send-error arms can map a send failure to a precise 413
+    // instead of a generic 502.
+    let body_oversized = Arc::new(AtomicBool::new(false));
+    let limited_body = LimitedBody::new(
+        body,
+        config.max_request_body_size,
+        Arc::clone(&body_oversized),
+    )
+    .boxed();
     let mut forward_req = Request::from_parts(parts, limited_body);
 
     // HTTP/2 (gRPC) requires an absolute URI (scheme + authority).
@@ -361,6 +379,15 @@ async fn handle_request(
         let res = match response_result {
             Ok(Ok(res)) => res,
             Ok(Err(e)) => {
+                // Known limitation: if the upstream sent its head before
+                // consuming the body, the 413 cannot be guaranteed (the send
+                // error then reflects a genuine failure). Matches H3 ingress.
+                if body_oversized.load(Ordering::Acquire) {
+                    return Ok(full_response(
+                        StatusCode::PAYLOAD_TOO_LARGE,
+                        "Request body too large",
+                    ));
+                }
                 error!("gRPC request failed: {}", e);
                 return Ok(full_response(
                     StatusCode::BAD_GATEWAY,
@@ -377,9 +404,14 @@ async fn handle_request(
         };
 
         let (parts, body) = res.into_parts();
-        // Stream the response body directly to preserve HTTP/2 trailers
+        // Stream the response body directly to preserve HTTP/2 trailers. Headers
+        // are already flushed here, so a per-frame stall aborts the body
+        // mid-stream (mirrors H3 send_streaming_response).
         return Ok(with_alt_svc_header(
-            Response::from_parts(parts, body.boxed()),
+            Response::from_parts(
+                parts,
+                TimeoutBody::new(body, config.response_timeout).boxed(),
+            ),
             &config,
         ));
     }
@@ -421,6 +453,15 @@ async fn handle_request(
     let res = match response_result {
         Ok(Ok(res)) => res,
         Ok(Err(e)) => {
+            // Known limitation: if the upstream sent its head before consuming
+            // the body, the 413 cannot be guaranteed (the send error then
+            // reflects a genuine failure). Matches H3 ingress.
+            if body_oversized.load(Ordering::Acquire) {
+                return Ok(full_response(
+                    StatusCode::PAYLOAD_TOO_LARGE,
+                    "Request body too large",
+                ));
+            }
             error!("Failed to send request: {}", e);
             return Ok(full_response(
                 StatusCode::BAD_GATEWAY,
@@ -490,7 +531,10 @@ async fn handle_request(
     let (parts, body) = res.into_parts();
 
     if !registry.needs_response_buffering().await {
-        let streaming_body = body.boxed();
+        // Headers are already flushed on the streaming path, so a stalled
+        // upstream aborts the body mid-stream via the per-frame timeout
+        // (mirrors H3 send_streaming_response). See RESPONSE_BODY_TIMEOUT_STATUS.
+        let streaming_body = TimeoutBody::new(body, config.response_timeout).boxed();
         return Ok(with_alt_svc_header(
             Response::from_parts(parts, streaming_body),
             &config,
@@ -550,6 +594,162 @@ async fn handle_request(
         Response::from_parts(final_parts, boxed_body),
         &config,
     ))
+}
+
+/// Error emitted by [`LimitedBody`] when the forwarded request body exceeds the cap.
+#[derive(Debug)]
+struct RequestBodyTooLarge;
+
+impl std::fmt::Display for RequestBodyTooLarge {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("request body exceeds configured maximum")
+    }
+}
+
+impl std::error::Error for RequestBodyTooLarge {}
+
+/// A request-body wrapper that hard-caps the bytes forwarded upstream.
+///
+/// Unlike `http_body_util::Limited` — whose error surfaces only mid-stream
+/// inside the upstream send path and gets mapped to a generic 502 — this wrapper
+/// flips the shared `exceeded` flag the instant a frame pushes the body past
+/// `remaining`. The ingress reads that flag in the upstream send-error arms and
+/// returns a precise `413 Payload Too Large`.
+struct LimitedBody<B> {
+    inner: B,
+    remaining: usize,
+    exceeded: Arc<AtomicBool>,
+}
+
+impl<B> LimitedBody<B> {
+    fn new(inner: B, remaining: usize, exceeded: Arc<AtomicBool>) -> Self {
+        Self {
+            inner,
+            remaining,
+            exceeded,
+        }
+    }
+}
+
+impl<B> hyper::body::Body for LimitedBody<B>
+where
+    B: hyper::body::Body<Data = Bytes> + Unpin,
+    B::Error: Into<BoxError>,
+{
+    type Data = Bytes;
+    type Error = BoxError;
+
+    fn poll_frame(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<std::result::Result<hyper::body::Frame<Self::Data>, Self::Error>>> {
+        let this = self.get_mut();
+        match Pin::new(&mut this.inner).poll_frame(cx) {
+            Poll::Ready(Some(Ok(frame))) => {
+                if let Some(data) = frame.data_ref() {
+                    if data.len() > this.remaining {
+                        this.exceeded.store(true, Ordering::Release);
+                        return Poll::Ready(Some(Err(Box::new(RequestBodyTooLarge))));
+                    }
+                    this.remaining -= data.len();
+                }
+                Poll::Ready(Some(Ok(frame)))
+            }
+            Poll::Ready(Some(Err(e))) => Poll::Ready(Some(Err(e.into()))),
+            Poll::Ready(None) => Poll::Ready(None),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+
+    fn is_end_stream(&self) -> bool {
+        self.inner.is_end_stream()
+    }
+
+    fn size_hint(&self) -> hyper::body::SizeHint {
+        self.inner.size_hint()
+    }
+}
+
+/// Status conceptually equivalent to a streaming-response per-frame timeout.
+///
+/// The streaming path flushes headers before the body, so a stall aborts the
+/// body mid-stream and no status can actually be sent. This const mirrors the
+/// buffered path's `BodyCollectError::Timeout` (504) and the H3 ingress for
+/// symmetry, and is asserted in tests.
+#[allow(dead_code)]
+const RESPONSE_BODY_TIMEOUT_STATUS: StatusCode = StatusCode::GATEWAY_TIMEOUT;
+
+/// Error emitted by [`TimeoutBody`] when the response body stalls between frames.
+#[derive(Debug)]
+struct ResponseBodyTimeout;
+
+impl std::fmt::Display for ResponseBodyTimeout {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("response body timed out between frames")
+    }
+}
+
+impl std::error::Error for ResponseBodyTimeout {}
+
+/// A response-body wrapper enforcing a per-frame inactivity timeout.
+///
+/// The streaming response path (when no plugin needs buffering) forwards the
+/// upstream body frame by frame. Without this guard a stalled upstream pins the
+/// connection indefinitely. The deadline resets on every delivered frame; while
+/// the inner body is `Pending` the sleep is polled and an elapse surfaces as a
+/// `ResponseBodyTimeout` error (mirrors H3 `send_streaming_response`).
+struct TimeoutBody<B> {
+    inner: B,
+    timeout: Duration,
+    sleep: Pin<Box<tokio::time::Sleep>>,
+}
+
+impl<B> TimeoutBody<B> {
+    fn new(inner: B, timeout: Duration) -> Self {
+        Self {
+            inner,
+            timeout,
+            sleep: Box::pin(tokio::time::sleep(timeout)),
+        }
+    }
+}
+
+impl<B> hyper::body::Body for TimeoutBody<B>
+where
+    B: hyper::body::Body<Data = Bytes> + Unpin,
+    B::Error: Into<BoxError>,
+{
+    type Data = Bytes;
+    type Error = BoxError;
+
+    fn poll_frame(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<std::result::Result<hyper::body::Frame<Self::Data>, Self::Error>>> {
+        let this = self.get_mut();
+        match Pin::new(&mut this.inner).poll_frame(cx) {
+            Poll::Ready(Some(Ok(frame))) => {
+                this.sleep
+                    .as_mut()
+                    .reset(tokio::time::Instant::now() + this.timeout);
+                Poll::Ready(Some(Ok(frame)))
+            }
+            Poll::Ready(Some(Err(e))) => Poll::Ready(Some(Err(e.into()))),
+            Poll::Ready(None) => Poll::Ready(None),
+            Poll::Pending => match this.sleep.as_mut().poll(cx) {
+                Poll::Ready(()) => Poll::Ready(Some(Err(Box::new(ResponseBodyTimeout)))),
+                Poll::Pending => Poll::Pending,
+            },
+        }
+    }
+
+    fn is_end_stream(&self) -> bool {
+        self.inner.is_end_stream()
+    }
+
+    fn size_hint(&self) -> hyper::body::SizeHint {
+        self.inner.size_hint()
+    }
 }
 
 /// Returns `true` if the request declares a `Content-Length` larger than `max_size`.
@@ -889,15 +1089,20 @@ mod tests {
         assert!(!content_length_exceeds(&headers, 1024));
     }
 
-    // Acceptance (1): an oversized request body is rejected. The `Limited`
-    // wrapper used on the forwarded request body errors once the cap is passed,
-    // hard-capping bodies that have no declared Content-Length.
+    // Acceptance (1): `LimitedBody` flips the shared flag and errors once a frame
+    // pushes the body past the cap, so the upstream send-error arm can map it to
+    // a 413 (rather than the generic 502 the old `Limited` wrapper produced).
     #[tokio::test]
-    async fn oversized_request_body_is_rejected_by_limited() {
+    async fn limited_body_sets_flag_and_errors_when_oversized() {
+        let exceeded = Arc::new(AtomicBool::new(false));
         let body = http_body_util::Full::new(Bytes::from(vec![0u8; 2048]));
-        let limited = http_body_util::Limited::new(body, 1024);
-        let result = limited.collect().await;
-        assert!(result.is_err(), "body over the limit must be rejected");
+        let limited = LimitedBody::new(body, 1024, Arc::clone(&exceeded));
+        let result = limited.boxed().collect().await;
+        assert!(result.is_err(), "body over the limit must error");
+        assert!(
+            exceeded.load(Ordering::Acquire),
+            "the shared exceeded flag must be set"
+        );
     }
 
     #[tokio::test]
@@ -917,11 +1122,11 @@ mod tests {
         type Error = std::convert::Infallible;
 
         fn poll_frame(
-            self: std::pin::Pin<&mut Self>,
-            _cx: &mut std::task::Context<'_>,
-        ) -> std::task::Poll<Option<std::result::Result<hyper::body::Frame<Self::Data>, Self::Error>>>
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Option<std::result::Result<hyper::body::Frame<Self::Data>, Self::Error>>>
         {
-            std::task::Poll::Pending
+            Poll::Pending
         }
     }
 
@@ -950,5 +1155,96 @@ mod tests {
         let body = http_body_util::Full::new(Bytes::from_static(b"hello"));
         let result = collect_body_with_limit(body, 1024, Duration::from_secs(5)).await;
         assert_eq!(result, Ok(Bytes::from_static(b"hello")));
+    }
+
+    // Acceptance (2): the streaming response path enforces a per-frame timeout, so
+    // a stalled upstream surfaces an error mid-stream instead of pinning the
+    // connection. `TimeoutBody` wraps a body that never yields a frame.
+    #[tokio::test]
+    async fn streaming_response_body_times_out_per_frame() {
+        use hyper::body::Body as _;
+
+        let mut body = TimeoutBody::new(StalledBody, Duration::from_millis(50));
+        let frame = std::future::poll_fn(|cx| Pin::new(&mut body).poll_frame(cx)).await;
+        assert!(matches!(frame, Some(Err(_))), "stalled body must time out");
+        assert_eq!(RESPONSE_BODY_TIMEOUT_STATUS, StatusCode::GATEWAY_TIMEOUT);
+    }
+
+    // Acceptance (1) end-to-end: a chunked request body (no Content-Length) that
+    // exceeds `max_request_body_size` is rejected with 413 through the real
+    // `handle_request` forward path, not a generic 502.
+    #[tokio::test]
+    async fn chunked_oversized_request_body_returns_413() {
+        use ferrotunnel_core::stream::{AnyMultiplexer, Multiplexer, PrioritizedFrame};
+        use ferrotunnel_core::tunnel::session::Session;
+        use kanal::bounded_async;
+
+        // Drain-backed multiplexer: outbound frames are discarded so open_stream
+        // and the upstream HTTP/1 handshake succeed without a real tunnel client.
+        let (frame_tx, frame_rx) = bounded_async::<PrioritizedFrame>(1024);
+        tokio::spawn(async move { while frame_rx.recv().await.is_ok() {} });
+        let (multiplexer, _new_stream_rx) = Multiplexer::new(frame_tx, true);
+
+        let tunnel_id = "oversized.test";
+        let sessions = SessionStoreBackend::default();
+        let session = Session::new(
+            uuid::Uuid::new_v4(),
+            tunnel_id.to_string(),
+            "127.0.0.1:0".parse().unwrap(),
+            "tok".into(),
+            vec![],
+            Some(AnyMultiplexer::Tcp(multiplexer)),
+        );
+        sessions.add(session).unwrap();
+
+        let config = IngressConfig {
+            max_request_body_size: 1024,
+            ..IngressConfig::default()
+        };
+
+        // Ingress side: an ephemeral listener driven by the real handle_request.
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let local_addr = listener.local_addr().unwrap();
+        let registry = Arc::new(PluginRegistry::new());
+        let peer_addr: SocketAddr = "127.0.0.1:12345".parse().unwrap();
+
+        tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let io = TokioIo::new(stream);
+            let service = service_fn(move |req| {
+                handle_request(
+                    req,
+                    sessions.clone(),
+                    registry.clone(),
+                    peer_addr,
+                    config.clone(),
+                )
+            });
+            let _ = AutoBuilder::new(TokioExecutor::new())
+                .serve_connection(io, service)
+                .await;
+        });
+
+        // Client side: send a CHUNKED body (StreamBody => no Content-Length).
+        let stream = tokio::net::TcpStream::connect(local_addr).await.unwrap();
+        let io = TokioIo::new(stream);
+        let (mut sender, conn) = hyper::client::conn::http1::handshake(io).await.unwrap();
+        tokio::spawn(async move {
+            let _ = conn.await;
+        });
+
+        let chunks: Vec<std::result::Result<hyper::body::Frame<Bytes>, std::convert::Infallible>> =
+            vec![Ok(hyper::body::Frame::data(Bytes::from(vec![0u8; 4096])))];
+        let body = http_body_util::StreamBody::new(futures::stream::iter(chunks));
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/")
+            .header("host", tunnel_id)
+            .body(body)
+            .unwrap();
+
+        let resp = sender.send_request(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::PAYLOAD_TOO_LARGE);
     }
 }

--- a/ferrotunnel-http/src/pool.rs
+++ b/ferrotunnel-http/src/pool.rs
@@ -164,19 +164,26 @@ impl ConnectionPool {
     }
 
     /// Acquire an HTTP/2 connection (multiplexed, shared)
+    ///
+    /// The pool mutex is only held while inspecting/storing the cached sender;
+    /// the TCP connect and HTTP/2 handshake run with the lock released so that
+    /// concurrent callers are not serialized behind a full reconnect. If two
+    /// callers race to dial, the loser drops its freshly created sender (whose
+    /// driver future resolves on drop, so no task leaks) and reuses the winner's.
     pub async fn acquire_h2(&self) -> Result<http2::SendRequest<BoxBody>, ConnectionPoolError> {
-        let mut h2_conn = self.h2_connection.lock().await;
-
-        // Check if we have a valid H2 connection
-        if let Some(ref sender) = *h2_conn {
-            if sender.is_ready() {
-                debug!("Reusing existing HTTP/2 connection");
-                return Ok(sender.clone());
+        // Fast path: reuse a ready cached connection, then drop the guard.
+        {
+            let h2_conn = self.h2_connection.lock().await;
+            if let Some(ref sender) = *h2_conn {
+                if sender.is_ready() {
+                    debug!("Reusing existing HTTP/2 connection");
+                    return Ok(sender.clone());
+                }
+                debug!("HTTP/2 connection not ready, creating new one");
             }
-            debug!("HTTP/2 connection not ready, creating new one");
         }
 
-        // Create new HTTP/2 connection
+        // Create a new HTTP/2 connection with the lock released.
         debug!("Creating new HTTP/2 connection to {}", self.target_addr);
         let stream = TcpStream::connect(&self.target_addr)
             .await
@@ -195,6 +202,16 @@ impl ConnectionPool {
                 debug!("HTTP/2 connection error: {:?}", e);
             }
         });
+
+        // Re-acquire the lock and double-check: another caller may have stored a
+        // ready connection while we were dialing. If so, reuse theirs and drop ours.
+        let mut h2_conn = self.h2_connection.lock().await;
+        if let Some(ref existing) = *h2_conn {
+            if existing.is_ready() {
+                debug!("Discarding redundant HTTP/2 connection, reusing concurrent one");
+                return Ok(existing.clone());
+            }
+        }
 
         *h2_conn = Some(sender.clone());
         Ok(sender)
@@ -224,6 +241,141 @@ impl ConnectionPool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// Spawn a minimal HTTP/2 upstream stub.
+    ///
+    /// Accepts TCP connections and completes a real HTTP/2 handshake so that a
+    /// client `SendRequest` becomes ready. `delay` is applied per connection
+    /// before serving, to simulate a slow upstream. Returns the bound address,
+    /// a counter of accepted inbound TCP connections, and the accept-loop task.
+    async fn spawn_h2_stub(
+        delay: Duration,
+    ) -> (String, Arc<AtomicUsize>, tokio::task::JoinHandle<()>) {
+        use bytes::Bytes;
+        use http_body_util::Full;
+        use hyper::body::Incoming;
+        use hyper::server::conn::http2 as server_http2;
+        use hyper::service::service_fn;
+        use hyper::{Request, Response};
+        use hyper_util::rt::TokioExecutor;
+        use tokio::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap().to_string();
+        let count = Arc::new(AtomicUsize::new(0));
+        let accept_count = count.clone();
+
+        let handle = tokio::spawn(async move {
+            loop {
+                let Ok((stream, _)) = listener.accept().await else {
+                    break;
+                };
+                accept_count.fetch_add(1, Ordering::SeqCst);
+                let conn_delay = delay;
+                tokio::spawn(async move {
+                    if !conn_delay.is_zero() {
+                        tokio::time::sleep(conn_delay).await;
+                    }
+                    let io = TokioIo::new(stream);
+                    let _ = server_http2::Builder::new(TokioExecutor::new())
+                        .serve_connection(
+                            io,
+                            service_fn(|_req: Request<Incoming>| async move {
+                                Ok::<_, std::convert::Infallible>(Response::new(Full::new(
+                                    Bytes::from_static(b"ok"),
+                                )))
+                            }),
+                        )
+                        .await;
+                });
+            }
+        });
+
+        (addr, count, handle)
+    }
+
+    /// Wait until the HTTP/2 sender finishes its handshake and is ready.
+    async fn wait_until_ready(sender: &http2::SendRequest<BoxBody>) {
+        for _ in 0..200u32 {
+            if sender.is_ready() {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        panic!("HTTP/2 sender never became ready");
+    }
+
+    /// Wait until the stub has accepted at least `target` inbound connections.
+    async fn wait_for_accepts(accepted: &Arc<AtomicUsize>, target: usize) {
+        for _ in 0..200u32 {
+            if accepted.load(Ordering::SeqCst) >= target {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        panic!(
+            "stub accepted {} connections, expected at least {target}",
+            accepted.load(Ordering::SeqCst)
+        );
+    }
+
+    #[tokio::test]
+    async fn acquire_h2_reuses_connection_without_redial() {
+        // #133: a second acquire_h2 must reuse the cached ready connection and
+        // must not open a new inbound TCP connection.
+        let (addr, accepted, _stub) = spawn_h2_stub(Duration::ZERO).await;
+        let pool = ConnectionPool::new(addr, PoolConfig::default());
+
+        let sender = pool.acquire_h2().await.expect("first acquire_h2");
+        // The client `SendRequest` can report ready before the server's
+        // userspace accept() runs, so confirm the dial actually landed.
+        wait_for_accepts(&accepted, 1).await;
+        wait_until_ready(&sender).await;
+        assert_eq!(
+            accepted.load(Ordering::SeqCst),
+            1,
+            "first acquire dials once"
+        );
+
+        let _second = pool.acquire_h2().await.expect("second acquire_h2");
+        // Allow any erroneous extra dial to be accepted before asserting.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert_eq!(
+            accepted.load(Ordering::SeqCst),
+            1,
+            "second acquire_h2 must reuse the cached connection"
+        );
+    }
+
+    #[tokio::test]
+    async fn concurrent_acquire_h2_is_not_serialized_by_the_lock() {
+        // #133: with the mutex released across connect + handshake, N concurrent
+        // dials overlap and finish in roughly one per-dial delay. The old code
+        // held the lock across I/O, serializing callers. Bounds are generous to
+        // stay non-flaky while still well under N x per-dial delay.
+        let per_dial = Duration::from_millis(200);
+        let n: u32 = 6;
+        let (addr, _accepted, _stub) = spawn_h2_stub(per_dial).await;
+        let pool = Arc::new(ConnectionPool::new(addr, PoolConfig::default()));
+
+        let start = Instant::now();
+        let mut handles = Vec::new();
+        for _ in 0..n {
+            let pool = pool.clone();
+            handles.push(tokio::spawn(async move { pool.acquire_h2().await.is_ok() }));
+        }
+        for handle in handles {
+            assert!(handle.await.unwrap(), "acquire_h2 should succeed");
+        }
+        let elapsed = start.elapsed();
+
+        let bound = per_dial * n / 2;
+        assert!(
+            elapsed < bound,
+            "concurrent acquire_h2 took {elapsed:?}, expected < {bound:?}"
+        );
+    }
 
     #[test]
     fn test_pool_config_default() {

--- a/ferrotunnel-http/src/proxy.rs
+++ b/ferrotunnel-http/src/proxy.rs
@@ -285,6 +285,15 @@ impl HttpProxy<tower::layer::util::Identity> {
 }
 
 impl<L> HttpProxy<L> {
+    /// Pool used to serve gRPC streams.
+    ///
+    /// Returns a clone of the shared pool so every gRPC stream multiplexes over
+    /// the same upstream HTTP/2 connection and shares one eviction task, instead
+    /// of allocating a fresh pool (and tasks/connections) per stream (see #134).
+    fn grpc_pool(&self) -> Arc<ConnectionPool> {
+        self.pool.clone()
+    }
+
     pub fn with_layer<NewL>(self, layer: NewL) -> HttpProxy<NewL> {
         HttpProxy {
             target_addr: self.target_addr,
@@ -320,9 +329,10 @@ impl<L> HttpProxy<L> {
     /// Serve an incoming gRPC `VirtualStream` over HTTP/2.
     ///
     /// gRPC requires HTTP/2 end-to-end so that trailers (`grpc-status`,
-    /// `grpc-message`) are propagated correctly. This method uses a
-    /// dedicated HTTP/2 connection pool (always acquired via `acquire_h2()`)
-    /// to forward requests to the local service.
+    /// `grpc-message`) are propagated correctly. This method reuses the shared
+    /// pool's multiplexed HTTP/2 connection (acquired via `acquire_h2()`) to
+    /// forward requests, so every gRPC stream shares one upstream connection and
+    /// eviction task rather than allocating a fresh pool per stream.
     pub fn handle_grpc_stream(&self, stream: VirtualStream)
     where
         L: Layer<LocalProxyService> + Clone + Send + 'static,
@@ -332,14 +342,10 @@ impl<L> HttpProxy<L> {
             + 'static,
         <L::Service as Service<Request<Incoming>>>::Future: Send,
     {
-        let grpc_pool = Arc::new(ConnectionPool::new(
-            self.target_addr.clone(),
-            PoolConfig::default(),
-        ));
         let service = self
             .layer
             .clone()
-            .layer(LocalProxyService::with_pool_h2(grpc_pool));
+            .layer(LocalProxyService::with_pool_h2(self.grpc_pool()));
         let hyper_service = TowerToHyperService::new(service);
         let io = TokioIo::new(stream);
 
@@ -436,5 +442,22 @@ mod tests {
         let proxy = HttpProxy::new("127.0.0.1:8080".to_string());
         let _layered = proxy.with_layer(tower::layer::util::Identity::new());
         // Just verify it compiles and runs
+    }
+
+    #[test]
+    fn grpc_stream_reuses_shared_pool() {
+        // #134: handle_grpc_stream must reuse the proxy's shared pool rather than
+        // allocating a brand-new ConnectionPool per VirtualStream. grpc_pool() is
+        // the single source of truth the handler uses for its H2 pool.
+        let proxy = HttpProxy::new("127.0.0.1:8080".to_string());
+        let grpc_pool = proxy.grpc_pool();
+
+        // Identity: the gRPC pool is the same allocation as the shared pool.
+        assert!(
+            Arc::ptr_eq(&grpc_pool, &proxy.pool),
+            "handle_grpc_stream must reuse self.pool, not allocate a new pool"
+        );
+        // Refcount: grpc_pool is a clone of the shared Arc, not a fresh one.
+        assert_eq!(Arc::strong_count(&proxy.pool), 2);
     }
 }

--- a/ferrotunnel-observability/Cargo.toml
+++ b/ferrotunnel-observability/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["network-programming"]
 include = ["src/**", "Cargo.toml", "README.md"]
 
 [dependencies]
-ferrotunnel-common = { version = "1.2.0", path = "../ferrotunnel-common" }
+ferrotunnel-common = { version = "1.3.0", path = "../ferrotunnel-common" }
 anyhow = { workspace = true }
 
 # Metrics

--- a/ferrotunnel/Cargo.toml
+++ b/ferrotunnel/Cargo.toml
@@ -12,11 +12,11 @@ keywords = ["tunnel", "reverse-proxy", "networking", "async"]
 categories = ["network-programming", "asynchronous"]
 
 [dependencies]
-ferrotunnel-common = { version = "1.2.0", path = "../ferrotunnel-common" }
-ferrotunnel-protocol = { version = "1.2.0", path = "../ferrotunnel-protocol" }
-ferrotunnel-core = { version = "1.2.0", path = "../ferrotunnel-core" }
-ferrotunnel-http = { version = "1.2.0", path = "../ferrotunnel-http" }
-ferrotunnel-plugin = { version = "1.2.0", path = "../ferrotunnel-plugin" }
+ferrotunnel-common = { version = "1.3.0", path = "../ferrotunnel-common" }
+ferrotunnel-protocol = { version = "1.3.0", path = "../ferrotunnel-protocol" }
+ferrotunnel-core = { version = "1.3.0", path = "../ferrotunnel-core" }
+ferrotunnel-http = { version = "1.3.0", path = "../ferrotunnel-http" }
+ferrotunnel-plugin = { version = "1.3.0", path = "../ferrotunnel-plugin" }
 
 # Re-export commonly used dependencies
 tokio = { workspace = true }

--- a/ferrotunnel/README.md
+++ b/ferrotunnel/README.md
@@ -65,7 +65,9 @@ async fn main() -> ferrotunnel::Result<()> {
         .token("my-token")
         .build()?;
 
-    server.start().await
+    server.start().await?;
+    tokio::signal::ctrl_c().await?;
+    server.shutdown().await
 }
 ```
 

--- a/ferrotunnel/src/client.rs
+++ b/ferrotunnel/src/client.rs
@@ -99,6 +99,7 @@ impl Client {
         let tunnel_id = config.tunnel_id.clone();
         let auto_reconnect = config.auto_reconnect;
         let reconnect_delay = config.reconnect_delay;
+        let startup_timeout = config.startup_timeout;
         let transport_config = self.transport_config.clone();
 
         let info_tx = Arc::new(Mutex::new(Some(info_tx)));
@@ -154,10 +155,27 @@ impl Client {
 
         self.task = Some(task);
 
-        // Wait for initial connection
-        info_rx
-            .await
-            .map_err(|_| TunnelError::Connection("Failed to establish connection".into()))
+        // Wait for initial connection, bounded by the optional startup timeout.
+        match startup_timeout {
+            Some(timeout) => match tokio::time::timeout(timeout, info_rx).await {
+                Ok(res) => res
+                    .map_err(|_| TunnelError::Connection("Failed to establish connection".into())),
+                Err(_elapsed) => {
+                    if let Some(tx) = self.shutdown_tx.take() {
+                        let _ = tx.send(true);
+                    }
+                    if let Some(task) = self.task.take() {
+                        task.abort();
+                    }
+                    Err(TunnelError::Timeout(
+                        "timed out waiting for initial connection".into(),
+                    ))
+                }
+            },
+            None => info_rx
+                .await
+                .map_err(|_| TunnelError::Connection("Failed to establish connection".into())),
+        }
     }
 
     async fn connect_once(
@@ -325,6 +343,16 @@ impl ClientBuilder {
         self
     }
 
+    /// Set the maximum time to wait for the initial connection in
+    /// [`Client::start`]. Pass `None` to wait indefinitely.
+    ///
+    /// Default: 30 seconds
+    #[must_use]
+    pub fn startup_timeout(mut self, timeout: Option<Duration>) -> Self {
+        self.config.startup_timeout = timeout;
+        self
+    }
+
     /// Configure TLS for the connection.
     ///
     /// When enabled, the client will use TLS to connect to the server.
@@ -441,6 +469,39 @@ mod tests {
             .build()
             .expect("should build");
 
+        assert!(!client.is_running());
+    }
+
+    #[test]
+    fn test_client_builder_startup_timeout_none_is_stored() {
+        let client = Client::builder()
+            .server_addr("localhost:7835")
+            .token("secret")
+            .startup_timeout(None)
+            .build()
+            .expect("should build");
+
+        assert_eq!(client.config().startup_timeout, None);
+    }
+
+    #[tokio::test]
+    async fn start_returns_error_on_unreachable_server_with_auto_reconnect() {
+        let mut client = Client::builder()
+            .server_addr("127.0.0.1:1")
+            .token("secret")
+            .auto_reconnect(true)
+            .reconnect_delay(Duration::from_millis(50))
+            .startup_timeout(Some(Duration::from_millis(300)))
+            .build()
+            .expect("should build");
+
+        let result = tokio::time::timeout(Duration::from_secs(5), client.start()).await;
+
+        let inner = result.expect("start() should resolve within the test deadline");
+        assert!(
+            inner.is_err(),
+            "start() should return an error when the server is unreachable"
+        );
         assert!(!client.is_running());
     }
 

--- a/ferrotunnel/src/config.rs
+++ b/ferrotunnel/src/config.rs
@@ -33,6 +33,9 @@ pub struct ClientConfig {
 
     /// Delay between reconnection attempts
     pub reconnect_delay: Duration,
+
+    /// Maximum time to wait for the initial connection in `start()`. `None` waits indefinitely. Default 30s.
+    pub startup_timeout: Option<Duration>,
 }
 
 impl ClientConfig {
@@ -60,6 +63,7 @@ impl Default for ClientConfig {
             tunnel_id: None,
             auto_reconnect: true,
             reconnect_delay: Duration::from_secs(5),
+            startup_timeout: Some(Duration::from_secs(30)),
         }
     }
 }
@@ -150,6 +154,7 @@ mod tests {
         assert_eq!(config.local_addr, "127.0.0.1:8080");
         assert!(config.auto_reconnect);
         assert_eq!(config.reconnect_delay, Duration::from_secs(5));
+        assert_eq!(config.startup_timeout, Some(Duration::from_secs(30)));
     }
 
     #[test]

--- a/ferrotunnel/src/lib.rs
+++ b/ferrotunnel/src/lib.rs
@@ -49,6 +49,8 @@
 //!         .build()?;
 //!
 //!     server.start().await?;
+//!     tokio::signal::ctrl_c().await?;
+//!     server.shutdown().await?;
 //!     Ok(())
 //! }
 //! ```

--- a/ferrotunnel/src/server.rs
+++ b/ferrotunnel/src/server.rs
@@ -13,6 +13,8 @@
 //!     .build()?;
 //!
 //! server.start().await?;
+//! tokio::signal::ctrl_c().await?;
+//! server.shutdown().await?;
 //! # Ok(())
 //! # }
 //! ```
@@ -70,24 +72,41 @@ impl Server {
         ServerBuilder::default()
     }
 
-    /// Start the tunnel server.
+    /// Start the tunnel server in the background.
     ///
-    /// This will bind to the configured addresses and start accepting connections.
-    /// The server runs until [`shutdown()`](Self::shutdown) is called.
+    /// This launches the configured tunnel and ingress services. The server runs until
+    /// [`shutdown()`](Self::shutdown) or [`stop()`](Self::stop) is called, or until one
+    /// of the service tasks exits.
     ///
     /// # Errors
     ///
     /// Returns an error if the server is already running.
-    #[allow(clippy::too_many_lines)]
     pub async fn start(&mut self) -> Result<()> {
-        if self.task.is_some() {
+        if self.is_running() {
             return Err(TunnelError::InvalidState("server already started".into()));
+        }
+        if let Some(task) = self.task.take() {
+            let _ = task.await;
         }
 
         let config = self.config.clone();
-        let (shutdown_tx, mut shutdown_rx) = watch::channel(false);
+        let transport_config = self.transport_config.clone();
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
         self.shutdown_tx = Some(shutdown_tx);
 
+        self.task = Some(tokio::spawn(async move {
+            Self::run_services(config, transport_config, shutdown_rx).await
+        }));
+
+        Ok(())
+    }
+
+    #[allow(clippy::too_many_lines)]
+    async fn run_services(
+        config: ServerConfig,
+        transport_config: TransportConfig,
+        mut shutdown_rx: watch::Receiver<bool>,
+    ) -> Result<()> {
         info!("Starting `FerroTunnel` Server");
         info!("  Tunnel bind: {}", config.bind_addr);
         info!("  HTTP bind: {}", config.http_bind_addr);
@@ -96,8 +115,10 @@ impl Server {
             info!("  HTTP/3 bind: {} (UDP)", http3_bind_addr);
         }
 
-        let tunnel_server = TunnelServer::new(config.bind_addr, config.token)
-            .with_transport(self.transport_config.clone());
+        #[cfg(feature = "quic")]
+        let tunnel_transport = transport_config.clone();
+        let tunnel_server =
+            TunnelServer::new(config.bind_addr, config.token).with_transport(transport_config);
 
         // Initialize plugins
         let mut registry = PluginRegistry::new();
@@ -132,8 +153,7 @@ impl Server {
 
         // Spawn both services
         #[cfg(feature = "quic")]
-        let tunnel_handle = {
-            let tunnel_transport = self.transport_config.clone();
+        let mut tunnel_handle = {
             let tunnel_bind_addr = config.bind_addr;
             tokio::spawn(async move {
                 if matches!(tunnel_transport, TransportConfig::Quic(_)) {
@@ -144,8 +164,8 @@ impl Server {
             })
         };
         #[cfg(not(feature = "quic"))]
-        let tunnel_handle = tokio::spawn(async move { tunnel_server.run().await });
-        let ingress_handle = tokio::spawn(async move { ingress.start().await });
+        let mut tunnel_handle = tokio::spawn(async move { tunnel_server.run().await });
+        let mut ingress_handle = tokio::spawn(async move { ingress.start().await });
 
         #[cfg(feature = "http3")]
         let http3_handle = if let Some(http3_bind_addr) = config.http3_bind_addr {
@@ -172,52 +192,57 @@ impl Server {
 
         // Wait for shutdown or either service to exit
         #[cfg(feature = "http3")]
-        if let Some(http3_handle) = http3_handle {
-            tokio::select! {
-                result = tunnel_handle => {
-                    match result {
-                        Ok(inner) => inner?,
-                        Err(e) => return Err(TunnelError::Connection(format!("Tunnel task panicked: {e}"))),
-                    }
+        if let Some(mut http3_handle) = http3_handle {
+            let result = tokio::select! {
+                result = &mut tunnel_handle => Self::service_result("Tunnel", result),
+                result = &mut ingress_handle => Self::service_result("Ingress", result),
+                result = &mut http3_handle => Self::service_result("HTTP/3 ingress", result),
+                changed = shutdown_rx.changed() => {
+                    Self::log_shutdown_result(&changed);
+                    Ok(())
                 }
-                result = ingress_handle => {
-                    match result {
-                        Ok(inner) => inner?,
-                        Err(e) => return Err(TunnelError::Connection(format!("Ingress task panicked: {e}"))),
-                    }
-                }
-                result = http3_handle => {
-                    match result {
-                        Ok(inner) => inner?,
-                        Err(e) => return Err(TunnelError::Connection(format!("HTTP/3 ingress task panicked: {e}"))),
-                    }
-                }
-                _ = shutdown_rx.changed() => {
-                    info!("Server shutdown requested");
-                }
-            }
-            return Ok(());
+            };
+            tunnel_handle.abort();
+            ingress_handle.abort();
+            http3_handle.abort();
+            return result;
         }
 
-        tokio::select! {
-            result = tunnel_handle => {
-                match result {
-                    Ok(inner) => inner?,
-                    Err(e) => return Err(TunnelError::Connection(format!("Tunnel task panicked: {e}"))),
-                }
+        let result = tokio::select! {
+            result = &mut tunnel_handle => Self::service_result("Tunnel", result),
+            result = &mut ingress_handle => Self::service_result("Ingress", result),
+            changed = shutdown_rx.changed() => {
+                Self::log_shutdown_result(&changed);
+                Ok(())
             }
-            result = ingress_handle => {
-                match result {
-                    Ok(inner) => inner?,
-                    Err(e) => return Err(TunnelError::Connection(format!("Ingress task panicked: {e}"))),
-                }
-            }
-            _ = shutdown_rx.changed() => {
+        };
+        tunnel_handle.abort();
+        ingress_handle.abort();
+
+        result
+    }
+
+    fn service_result(
+        name: &str,
+        result: std::result::Result<Result<()>, tokio::task::JoinError>,
+    ) -> Result<()> {
+        match result {
+            Ok(inner) => inner,
+            Err(e) => Err(TunnelError::Connection(format!(
+                "{name} task panicked: {e}"
+            ))),
+        }
+    }
+
+    fn log_shutdown_result(changed: &std::result::Result<(), watch::error::RecvError>) {
+        match changed {
+            Ok(()) => {
                 info!("Server shutdown requested");
             }
+            Err(_) => {
+                info!("Server shutdown channel closed");
+            }
         }
-
-        Ok(())
     }
 
     /// Shutdown the tunnel server and wait for cleanup.
@@ -228,7 +253,14 @@ impl Server {
             let _ = tx.send(true);
         }
         if let Some(task) = self.task.take() {
-            let _ = task.await;
+            match task.await {
+                Ok(result) => result?,
+                Err(e) => {
+                    return Err(TunnelError::Connection(format!(
+                        "Server task panicked: {e}"
+                    )));
+                }
+            }
         }
         Ok(())
     }
@@ -247,7 +279,7 @@ impl Server {
         if let Some(task) = &self.task {
             !task.is_finished()
         } else {
-            self.shutdown_tx.is_some()
+            false
         }
     }
 
@@ -418,6 +450,28 @@ mod tests {
             .build()
             .expect("should build");
 
+        assert!(!server.is_running());
+    }
+
+    #[tokio::test]
+    async fn test_server_start_shutdown_lifecycle() {
+        let mut server = Server::builder()
+            .bind("127.0.0.1:0".parse().unwrap())
+            .http_bind("127.0.0.1:0".parse().unwrap())
+            .token("secret")
+            .build()
+            .expect("should build");
+
+        server.start().await.expect("server should start");
+        assert!(server.is_running());
+
+        let err = server
+            .start()
+            .await
+            .expect_err("second start should fail while running");
+        assert!(err.to_string().contains("already started"));
+
+        server.shutdown().await.expect("server should shut down");
         assert!(!server.is_running());
     }
 

--- a/tests/integration/concurrent_test.rs
+++ b/tests/integration/concurrent_test.rs
@@ -1,7 +1,7 @@
 //! Concurrency integration tests
 
-use super::{start_echo_server, wait_for_server, TestConfig};
-use ferrotunnel::{Client, Server};
+use super::{start_echo_server, start_test_server, TestConfig};
+use ferrotunnel::Client;
 use std::sync::{
     atomic::{AtomicUsize, Ordering},
     Arc,
@@ -16,19 +16,7 @@ async fn test_concurrent_requests() {
     // Start local echo service
     let _echo_handle = start_echo_server(config.local_service_addr).await;
 
-    // Start server
-    let mut server = Server::builder()
-        .bind(config.server_addr)
-        .http_bind(config.http_addr)
-        .token(config.token)
-        .build()
-        .expect("Failed to build server");
-
-    let _server_handle = tokio::spawn(async move {
-        let _ = server.start().await;
-    });
-
-    assert!(wait_for_server(config.server_addr, Duration::from_secs(5)).await);
+    let mut server = start_test_server(&config).await;
 
     // Start client
     let mut client = Client::builder()
@@ -81,4 +69,5 @@ async fn test_concurrent_requests() {
     );
 
     let _ = client.shutdown().await;
+    let _ = server.shutdown().await;
 }

--- a/tests/integration/error_test.rs
+++ b/tests/integration/error_test.rs
@@ -1,7 +1,7 @@
 //! Error scenario integration tests
 
-use super::{wait_for_server, TestConfig};
-use ferrotunnel::{Client, Server};
+use super::{start_test_server, TestConfig};
+use ferrotunnel::Client;
 use std::time::Duration;
 
 /// Test upstream connection refused (tunnel -> local service fails)
@@ -11,19 +11,7 @@ async fn test_upstream_connection_refused() {
 
     // Do NOT start local service -> Connection refused
 
-    // Start server
-    let mut server = Server::builder()
-        .bind(config.server_addr)
-        .http_bind(config.http_addr)
-        .token(config.token)
-        .build()
-        .expect("Failed to build server");
-
-    let _server_handle = tokio::spawn(async move {
-        let _ = server.start().await;
-    });
-
-    assert!(wait_for_server(config.server_addr, Duration::from_secs(5)).await);
+    let mut server = start_test_server(&config).await;
 
     // Start client
     let mut client = Client::builder()
@@ -53,6 +41,7 @@ async fn test_upstream_connection_refused() {
     assert_eq!(response.status(), 502);
 
     let _ = client.shutdown().await;
+    let _ = server.shutdown().await;
 }
 
 /// Test upstream timeout

--- a/tests/integration/grpc_test.rs
+++ b/tests/integration/grpc_test.rs
@@ -95,9 +95,7 @@ async fn test_grpc_tunnel() {
         .build()
         .expect("Failed to build server");
 
-    let _server_handle = tokio::spawn(async move {
-        let _ = server.start().await;
-    });
+    server.start().await.expect("Failed to start server");
 
     assert!(
         wait_for_server(server_addr, Duration::from_secs(5)).await,
@@ -189,6 +187,9 @@ async fn test_grpc_tunnel() {
         Some("0"),
         "Expected grpc-status: 0 trailer to be preserved through the tunnel"
     );
+
+    let _ = client.shutdown().await;
+    let _ = server.shutdown().await;
 }
 
 /// Verifies that ordinary HTTP/1.1 requests are NOT classified as gRPC
@@ -240,9 +241,7 @@ async fn test_non_grpc_not_classified_as_grpc() {
         .build()
         .expect("Failed to build server");
 
-    let _server_handle = tokio::spawn(async move {
-        let _ = server.start().await;
-    });
+    server.start().await.expect("Failed to start server");
 
     assert!(
         wait_for_server(server_addr, Duration::from_secs(5)).await,
@@ -287,4 +286,7 @@ async fn test_non_grpc_not_classified_as_grpc() {
         ct, "text/plain",
         "Expected text/plain, not gRPC content-type"
     );
+
+    let _ = client.shutdown().await;
+    let _ = server.shutdown().await;
 }

--- a/tests/integration/http3_test.rs
+++ b/tests/integration/http3_test.rs
@@ -84,7 +84,7 @@ async fn test_http3_request_through_tunnel_and_alt_svc_advertised() {
         .token(token)
         .build()
         .expect("Failed to build HTTP/3 server");
-    let server_handle = tokio::spawn(async move { server.start().await });
+    server.start().await.expect("Failed to start server");
 
     assert!(
         wait_for_server(context.server_addr, Duration::from_secs(5)).await,
@@ -129,7 +129,7 @@ async fn test_http3_request_through_tunnel_and_alt_svc_advertised() {
     assert!(body.contains("Hello, World!"));
 
     let _ = client.shutdown().await;
-    server_handle.abort();
+    let _ = server.shutdown().await;
 }
 
 #[tokio::test]
@@ -150,7 +150,7 @@ async fn test_http3_unknown_host_returns_not_found() {
         .token("test-http3-token")
         .build()
         .expect("Failed to build HTTP/3 server");
-    let server_handle = tokio::spawn(async move { server.start().await });
+    server.start().await.expect("Failed to start server");
 
     assert!(
         wait_for_server(context.server_addr, Duration::from_secs(5)).await,
@@ -162,7 +162,7 @@ async fn test_http3_unknown_host_returns_not_found() {
     assert_eq!(status, http::StatusCode::NOT_FOUND);
     assert_eq!(body, "Tunnel not found");
 
-    server_handle.abort();
+    let _ = server.shutdown().await;
 }
 
 async fn send_h3_get(

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -69,6 +69,23 @@ pub async fn wait_for_server(addr: SocketAddr, timeout: Duration) -> bool {
     false
 }
 
+pub async fn start_test_server(config: &TestConfig) -> ferrotunnel::Server {
+    let mut server = ferrotunnel::Server::builder()
+        .bind(config.server_addr)
+        .http_bind(config.http_addr)
+        .token(config.token)
+        .build()
+        .expect("Failed to build server");
+
+    server.start().await.expect("Failed to start server");
+    assert!(
+        wait_for_server(config.server_addr, Duration::from_secs(5)).await,
+        "Server did not start in time"
+    );
+
+    server
+}
+
 /// Start a simple HTTP server that echoes requests
 pub async fn start_echo_server(addr: SocketAddr) -> tokio::task::JoinHandle<()> {
     use tokio::io::{AsyncReadExt, AsyncWriteExt};

--- a/tests/integration/multi_client_test.rs
+++ b/tests/integration/multi_client_test.rs
@@ -2,8 +2,8 @@
 //!
 //! Tests scenarios with multiple concurrent tunnel clients
 
-use super::{start_echo_server, wait_for_server, TestConfig};
-use ferrotunnel::{Client, Server};
+use super::{start_echo_server, start_test_server, TestConfig};
+use ferrotunnel::Client;
 use std::time::Duration;
 
 /// Test multiple clients connecting to same server
@@ -19,20 +19,7 @@ async fn test_multiple_clients() {
     let _echo1 = start_echo_server(config.local_service_addr).await;
     let _echo2 = start_echo_server(local_addr2.parse().unwrap()).await;
 
-    // Start server
-    let mut server = Server::builder()
-        .bind(config.server_addr)
-        .http_bind(config.http_addr)
-        .token(config.token)
-        .build()
-        .expect("Failed to build server");
-
-    let _server_handle = tokio::spawn(async move {
-        let _ = server.start().await;
-    });
-
-    // Wait for server
-    assert!(wait_for_server(config.server_addr, Duration::from_secs(5)).await);
+    let mut server = start_test_server(&config).await;
 
     // Start first client
     let mut client1 = Client::builder()
@@ -63,6 +50,7 @@ async fn test_multiple_clients() {
     // Cleanup
     let _ = client1.shutdown().await;
     let _ = client2.shutdown().await;
+    let _ = server.shutdown().await;
 }
 
 /// Test client reconnection behavior
@@ -73,19 +61,7 @@ async fn test_client_reconnect() {
     // Start local service
     let _echo = start_echo_server(config.local_service_addr).await;
 
-    // Start server
-    let mut server = Server::builder()
-        .bind(config.server_addr)
-        .http_bind(config.http_addr)
-        .token(config.token)
-        .build()
-        .expect("Failed to build server");
-
-    let _server_handle = tokio::spawn(async move {
-        let _ = server.start().await;
-    });
-
-    assert!(wait_for_server(config.server_addr, Duration::from_secs(5)).await);
+    let mut server = start_test_server(&config).await;
 
     // First connection
     let mut client = Client::builder()
@@ -121,4 +97,5 @@ async fn test_client_reconnect() {
     );
 
     let _ = client2.shutdown().await;
+    let _ = server.shutdown().await;
 }

--- a/tests/integration/quic_test.rs
+++ b/tests/integration/quic_test.rs
@@ -219,7 +219,7 @@ async fn test_public_api_quic_routing() {
         .build()
         .expect("Failed to build QUIC server");
 
-    let server_handle = tokio::spawn(async move { server.start().await });
+    server.start().await.expect("Failed to start server");
 
     assert!(
         wait_for_quic_server(quic_addr, &cert_path, Duration::from_secs(5)).await,
@@ -262,6 +262,6 @@ async fn test_public_api_quic_routing() {
     assert!(text.contains("Hello, World!"));
 
     let _ = client.shutdown().await;
-    server_handle.abort();
+    let _ = server.shutdown().await;
     let _ = std::fs::remove_dir_all(temp_dir);
 }

--- a/tests/integration/tls_test.rs
+++ b/tests/integration/tls_test.rs
@@ -55,9 +55,7 @@ async fn test_tls_connection() {
         .build()
         .expect("Failed to build server");
 
-    let _server_handle = tokio::spawn(async move {
-        let _ = server.start().await;
-    });
+    server.start().await.expect("Failed to start server");
 
     // Wait for server? (Should we check TCP connect?)
     // But plain TCP connect might hang on handshake if we don't speak TLS?
@@ -91,5 +89,6 @@ async fn test_tls_connection() {
 
     // Clean up
     let _ = client.shutdown().await;
+    let _ = server.shutdown().await;
     let _ = std::fs::remove_dir_all(temp_dir);
 }

--- a/tests/integration/tunnel_test.rs
+++ b/tests/integration/tunnel_test.rs
@@ -2,7 +2,7 @@
 //!
 //! Tests basic tunnel functionality: server, client, HTTP routing
 
-use super::{start_echo_server, wait_for_server, TestConfig};
+use super::{start_echo_server, start_test_server, TestConfig};
 use ferrotunnel::{Client, Server};
 use std::time::Duration;
 
@@ -18,17 +18,10 @@ async fn test_server_starts() {
         .build()
         .expect("Failed to build server");
 
-    // Start server in background
-    let server_handle = tokio::spawn(async move { server.start().await });
-
-    // Wait for server to be ready
-    assert!(
-        wait_for_server(config.server_addr, Duration::from_secs(5)).await,
-        "Server did not start in time"
-    );
-
-    // Clean up
-    server_handle.abort();
+    server.start().await.expect("Failed to start server");
+    assert!(server.is_running());
+    server.shutdown().await.expect("Failed to stop server");
+    assert!(!server.is_running());
 }
 
 /// Test that client connects to server
@@ -39,23 +32,7 @@ async fn test_client_connects() {
     // Start local service
     let _echo_handle = start_echo_server(config.local_service_addr).await;
 
-    // Start server
-    let mut server = Server::builder()
-        .bind(config.server_addr)
-        .http_bind(config.http_addr)
-        .token(config.token)
-        .build()
-        .expect("Failed to build server");
-
-    let _server_handle = tokio::spawn(async move {
-        let _ = server.start().await;
-    });
-
-    // Wait for server
-    assert!(
-        wait_for_server(config.server_addr, Duration::from_secs(5)).await,
-        "Server did not start"
-    );
+    let mut server = start_test_server(&config).await;
 
     // Build and start client
     let mut client = Client::builder()
@@ -77,6 +54,7 @@ async fn test_client_connects() {
 
     // Shutdown
     let _ = client.shutdown().await;
+    let _ = server.shutdown().await;
 }
 
 /// Test full HTTP request through tunnel
@@ -87,20 +65,7 @@ async fn test_http_through_tunnel() {
     // Start local echo service
     let _echo_handle = start_echo_server(config.local_service_addr).await;
 
-    // Start server
-    let mut server = Server::builder()
-        .bind(config.server_addr)
-        .http_bind(config.http_addr)
-        .token(config.token)
-        .build()
-        .expect("Failed to build server");
-
-    let _server_handle = tokio::spawn(async move {
-        let _ = server.start().await;
-    });
-
-    // Wait for server
-    assert!(wait_for_server(config.server_addr, Duration::from_secs(5)).await);
+    let mut server = start_test_server(&config).await;
 
     // Start client
     let mut client = Client::builder()
@@ -143,6 +108,7 @@ async fn test_http_through_tunnel() {
     );
 
     let _ = client.shutdown().await;
+    let _ = server.shutdown().await;
 }
 
 /// Test large payload handling
@@ -153,19 +119,7 @@ async fn test_large_payload() {
     // Start local sink service that reads everything and replies OK
     let _sink_handle = super::start_sink_server(config.local_service_addr).await;
 
-    // Start server
-    let mut server = Server::builder()
-        .bind(config.server_addr)
-        .http_bind(config.http_addr)
-        .token(config.token)
-        .build()
-        .expect("Failed to build server");
-
-    let _server_handle = tokio::spawn(async move {
-        let _ = server.start().await;
-    });
-
-    assert!(wait_for_server(config.server_addr, Duration::from_secs(5)).await);
+    let mut server = start_test_server(&config).await;
 
     // Start client
     let mut client = Client::builder()
@@ -205,4 +159,5 @@ async fn test_large_payload() {
     );
 
     let _ = client.shutdown().await;
+    let _ = server.shutdown().await;
 }

--- a/tests/integration/websocket_test.rs
+++ b/tests/integration/websocket_test.rs
@@ -54,9 +54,7 @@ async fn test_websocket_upgrade_through_tunnel() {
         .build()
         .expect("Failed to build server");
 
-    let _server_handle = tokio::spawn(async move {
-        let _ = server.start().await;
-    });
+    server.start().await.expect("Failed to start server");
 
     assert!(
         wait_for_server(server_addr, Duration::from_secs(5)).await,
@@ -130,6 +128,7 @@ async fn test_websocket_upgrade_through_tunnel() {
     drop(read);
 
     let _ = client.shutdown().await;
+    let _ = server.shutdown().await;
 }
 
 #[tokio::test]
@@ -151,9 +150,7 @@ async fn test_websocket_raw_upgrade_101() {
         .build()
         .expect("Failed to build server");
 
-    let _server_handle = tokio::spawn(async move {
-        let _ = server.start().await;
-    });
+    server.start().await.expect("Failed to start server");
 
     assert!(
         wait_for_server(server_addr, Duration::from_secs(5)).await,
@@ -210,6 +207,7 @@ async fn test_websocket_raw_upgrade_101() {
     );
 
     let _ = client.shutdown().await;
+    let _ = server.shutdown().await;
 }
 
 #[allow(clippy::result_large_err, clippy::unnecessary_wraps)]
@@ -260,9 +258,7 @@ async fn test_websocket_subprotocol_preserved() {
         .build()
         .expect("Failed to build server");
 
-    let _server_handle = tokio::spawn(async move {
-        let _ = server.start().await;
-    });
+    server.start().await.expect("Failed to start server");
 
     wait_for_server(server_addr, Duration::from_secs(5)).await;
 
@@ -293,6 +289,7 @@ async fn test_websocket_subprotocol_preserved() {
     assert_eq!(response.status(), http::StatusCode::SWITCHING_PROTOCOLS);
 
     let _ = client.shutdown().await;
+    let _ = server.shutdown().await;
 }
 
 #[tokio::test]
@@ -314,9 +311,7 @@ async fn test_websocket_multiple_concurrent_streams() {
         .build()
         .expect("Failed to build server");
 
-    let _server_handle = tokio::spawn(async move {
-        let _ = server.start().await;
-    });
+    server.start().await.expect("Failed to start server");
 
     wait_for_server(server_addr, Duration::from_secs(5)).await;
 
@@ -365,6 +360,7 @@ async fn test_websocket_multiple_concurrent_streams() {
     }
 
     let _ = client.shutdown().await;
+    let _ = server.shutdown().await;
 }
 
 #[tokio::test]
@@ -407,9 +403,7 @@ async fn test_websocket_failed_upgrade_404() {
         .build()
         .expect("Failed to build server");
 
-    let _server_handle = tokio::spawn(async move {
-        let _ = server.start().await;
-    });
+    server.start().await.expect("Failed to start server");
 
     wait_for_server(server_addr, Duration::from_secs(5)).await;
 
@@ -442,4 +436,5 @@ async fn test_websocket_failed_upgrade_404() {
     }
 
     let _ = client.shutdown().await;
+    let _ = server.shutdown().await;
 }

--- a/tools/soak/Cargo.toml
+++ b/tools/soak/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 publish = false
 
 [dependencies]
-ferrotunnel = { version = "1.2.0", path = "../../ferrotunnel" }
+ferrotunnel = { version = "1.3.0", path = "../../ferrotunnel" }
 tokio = { workspace = true }
 clap = { version = "4", features = ["derive"] }
 anyhow = { workspace = true }


### PR DESCRIPTION
## Release 1.3.0

Bug-fix / hardening release. Every v1.3.0 milestone issue fixed in-branch with tests; `fmt`, `clippy -D warnings` (default + all-features), full workspace suite, and rustdoc all green locally.

### Issues
- [x] **#120** — Supervise server lifecycle task so `is_running()` / `shutdown()` / double-start guard work (PR #149)
- [x] **#117** — `Client::start()` honors a `startup_timeout` instead of hanging forever on initial connect failure with auto-reconnect
- [x] **#118** — Atomic duplicate `tunnel_id` registration via DashMap `entry()` (TOCTOU fix)
- [x] **#129** — Spawn each TCP virtual-stream handler concurrently instead of awaiting sequentially
- [x] **#133** — Don't hold the H2 pool mutex across connect/handshake (double-checked store)
- [x] **#134** — Reuse the shared connection pool for gRPC streams (no per-stream pool/eviction task)
- [x] **#159** — Ingress: chunked oversized request → 413; per-frame timeout on the streaming response path

Closes #117, #118, #120, #129, #133, #134, #159.
