### PR TITLE
Release/1.4.0 — Protocol & Config Hardening

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,15 @@ Internet → HttpIngress(:8080) → SessionStore → AnyMultiplexer → [TCP: Mu
 - Prefer `Bytes` for zero-copy buffers, `kanal` for async channels, `DashMap` for concurrent maps
 - TLS uses `rustls` 0.23 + ring crypto provider (must call `install_default()` before any TLS config)
 
+## Public-Facing Wording
+
+Keep all public-facing text — commit messages, rustdoc (`///` doc comments),
+`CHANGELOG.md`, `ROADMAP.md`, and GitHub issues/PRs — **neutral and
+outcome-focused**. Do **not** reference internal tooling, code-review services,
+AI assistants, private decisions, or how the change was produced; describe
+*what* changed and *why* it matters to users. Commit messages stay short and
+imperative; rustdoc stays brief with no meta-commentary or disclaimers.
+
 ## Publishing
 
 Crates must be published in dependency order:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.0] - 2026-07-03
+
+Protocol and configuration hardening release closing the v1.4.0 milestone.
+
+### Security
+
+- Validate every wire-frame variant in the decode path so oversized or
+  high-cardinality control-frame contents are rejected before use, closing an
+  allocation-amplification vector reachable by an authenticated peer ([#139](https://github.com/ferro-labs/ferrotunnel/issues/139)).
+- Bound the control-frame decode allocation to the frame size, so a small frame
+  can no longer force a large allocation while decoding, and large allocations
+  require a proportionally large frame ([#163](https://github.com/ferro-labs/ferrotunnel/issues/163)).
+
+### Fixed
+
+- Wire the configured frame/limit settings through to the codec so
+  `max_frame_bytes` is enforced by client and server, and reject a zero or
+  oversized configured limit ([#144](https://github.com/ferro-labs/ferrotunnel/issues/144)).
+- Install the rustls crypto provider automatically for embedded library TLS
+  users, so `Client`/`Server` builders no longer require a manual provider
+  install ([#121](https://github.com/ferro-labs/ferrotunnel/issues/121)).
+
 ## [1.3.0] - 2026-06-26
 
 Bug-fix and reliability release closing the v1.3.0 milestone.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.3.0"
+version = "1.4.0"
 edition = "2021"
 rust-version = "1.91"
 authors = ["Mitul Shah <hello@ferrolabs.ai>"]
@@ -53,7 +53,7 @@ tokio = { version = "1", features = ["full"] }
 
 # Logging
 tracing = "0.1"
-ferrotunnel-observability = { version = "1.3.0", path = "ferrotunnel-observability" }
+ferrotunnel-observability = { version = "1.4.0", path = "ferrotunnel-observability" }
 
 # QUIC transport
 quinn = { version = "0.11", default-features = false, features = ["runtime-tokio", "rustls-ring"] }

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -53,6 +53,12 @@ Embeddable, extensible, and observable reverse tunnel for Rust developers.
   - CLI flags: `--quic-bind` (server), `--quic` / `--quic-0rtt` (client)
   - **Differentiator**: Next-gen transport for competitive advantage
 
+- **v1.1.0 – v1.4.0** - Security & Reliability Hardening ✅
+  - Audit-driven hardening across dashboard/TLS auth (v1.1.0), ingress and
+    session-resource limits (v1.2.0), concurrency and lifecycle correctness
+    (v1.3.0), and wire-protocol and configuration hardening (v1.4.0)
+  - **Value**: Production-grade robustness ahead of the API-stabilization window
+
 ### Planned
 
 > **Strategy**: Prioritize features that maximize user adoption and "time to first success"

--- a/ferrotunnel-cli/Cargo.toml
+++ b/ferrotunnel-cli/Cargo.toml
@@ -53,10 +53,6 @@ bytes = { workspace = true }
 # Memory allocator
 mimalloc = { workspace = true }
 
-# TLS crypto provider — must be explicitly installed as process default
-# before any rustls ClientConfig/ServerConfig is built (see issue #98)
-rustls = { version = "0.23", default-features = false, features = ["ring", "std"] }
-
 [features]
 http3 = ["ferrotunnel-http/http3"]
 quic = ["ferrotunnel-core/quic"]

--- a/ferrotunnel-cli/Cargo.toml
+++ b/ferrotunnel-cli/Cargo.toml
@@ -17,12 +17,12 @@ doc = false
 
 [dependencies]
 # Core functionality
-ferrotunnel-core = { version = "1.3.0", path = "../ferrotunnel-core", features = [
+ferrotunnel-core = { version = "1.4.0", path = "../ferrotunnel-core", features = [
     "metrics",
 ] }
-ferrotunnel-http = { version = "1.3.0", path = "../ferrotunnel-http" }
-ferrotunnel-protocol = { version = "1.3.0", path = "../ferrotunnel-protocol" }
-ferrotunnel-plugin = { version = "1.3.0", path = "../ferrotunnel-plugin" }
+ferrotunnel-http = { version = "1.4.0", path = "../ferrotunnel-http" }
+ferrotunnel-protocol = { version = "1.4.0", path = "../ferrotunnel-protocol" }
+ferrotunnel-plugin = { version = "1.4.0", path = "../ferrotunnel-plugin" }
 ferrotunnel-observability = { workspace = true, features = [
     "dashboard",
     "axum",

--- a/ferrotunnel-cli/src/main.rs
+++ b/ferrotunnel-cli/src/main.rs
@@ -41,13 +41,9 @@ enum Commands {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    // rustls 0.23 requires explicitly installing the crypto provider before any
-    // TLS connection is attempted. The `ring` feature makes the provider
-    // available but does NOT auto-install it (see ferro-labs/ferrotunnel#98).
-    // We ignore the Err case because install_default() fails only when another
-    // provider has already been installed (e.g. in tests), which is fine.
-    let _ = rustls::crypto::ring::default_provider().install_default();
-
+    // The rustls crypto provider is installed on demand by the library's TLS
+    // setup (`ferrotunnel-core` transport and the HTTP/3 ingress) before any TLS
+    // config is built, so the CLI does not install it here.
     let cli = Cli::parse();
 
     match cli.command {

--- a/ferrotunnel-core/Cargo.toml
+++ b/ferrotunnel-core/Cargo.toml
@@ -12,8 +12,8 @@ keywords = ["tunnel", "networking", "async", "core"]
 categories = ["network-programming", "asynchronous"]
 
 [dependencies]
-ferrotunnel-common = { version = "1.3.0", path = "../ferrotunnel-common" }
-ferrotunnel-protocol = { version = "1.3.0", path = "../ferrotunnel-protocol" }
+ferrotunnel-common = { version = "1.4.0", path = "../ferrotunnel-common" }
+ferrotunnel-protocol = { version = "1.4.0", path = "../ferrotunnel-protocol" }
 
 tokio = { workspace = true }
 tokio-util = { workspace = true }
@@ -54,7 +54,7 @@ crossbeam-queue = "0.3"
 quinn = { workspace = true, optional = true }
 
 # Optional metrics (decode/encode latency, queue depth)
-ferrotunnel-observability = { version = "1.3.0", path = "../ferrotunnel-observability", optional = true }
+ferrotunnel-observability = { version = "1.4.0", path = "../ferrotunnel-observability", optional = true }
 
 # File descriptor exhaustion (EMFILE/ENFILE) detection in accept-loop backoff
 [target.'cfg(unix)'.dependencies]

--- a/ferrotunnel-core/src/lib.rs
+++ b/ferrotunnel-core/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod auth;
+pub mod limits;
 pub mod rate_limit;
 pub mod reconnect;
 pub mod resource_limits;
@@ -7,5 +8,6 @@ pub mod transport;
 pub mod tunnel;
 
 // Re-export specific items for convenience
+pub use limits::validate_limits;
 pub use tunnel::client::TunnelClient;
 pub use tunnel::server::TunnelServer;

--- a/ferrotunnel-core/src/limits.rs
+++ b/ferrotunnel-core/src/limits.rs
@@ -1,0 +1,98 @@
+//! Validation for [`LimitsConfig`] shared by the client, server, and the
+//! public builder crate.
+
+use ferrotunnel_common::{LimitsConfig, Result, TunnelError};
+use ferrotunnel_protocol::constants::MAX_FRAME_SIZE;
+
+/// Validate resource limits before they are used to build codecs and semaphores.
+///
+/// Rejects values that would either panic codec construction (`max_frame_bytes`
+/// of zero or above the protocol frame ceiling) or create a zero-permit
+/// semaphore that blocks all sessions/streams.
+///
+/// # Errors
+///
+/// Returns [`TunnelError::Config`] describing the first offending field.
+pub fn validate_limits(limits: &LimitsConfig) -> Result<()> {
+    if limits.max_frame_bytes == 0 {
+        return Err(TunnelError::Config(
+            "limits.max_frame_bytes must be greater than zero".into(),
+        ));
+    }
+    if limits.max_frame_bytes > u64::from(MAX_FRAME_SIZE) {
+        return Err(TunnelError::Config(format!(
+            "limits.max_frame_bytes must not exceed {MAX_FRAME_SIZE} bytes"
+        )));
+    }
+    if limits.max_sessions == 0 {
+        return Err(TunnelError::Config(
+            "limits.max_sessions must be greater than zero".into(),
+        ));
+    }
+    if limits.max_streams_per_session == 0 {
+        return Err(TunnelError::Config(
+            "limits.max_streams_per_session must be greater than zero".into(),
+        ));
+    }
+    if limits.max_inflight_frames == 0 {
+        return Err(TunnelError::Config(
+            "limits.max_inflight_frames must be greater than zero".into(),
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_default_limits() {
+        assert!(validate_limits(&LimitsConfig::default()).is_ok());
+    }
+
+    #[test]
+    fn rejects_zero_frame_bytes() {
+        let limits = LimitsConfig {
+            max_frame_bytes: 0,
+            ..Default::default()
+        };
+        assert!(validate_limits(&limits).is_err());
+    }
+
+    #[test]
+    fn rejects_frame_bytes_above_ceiling() {
+        let limits = LimitsConfig {
+            max_frame_bytes: u64::from(MAX_FRAME_SIZE) + 1,
+            ..Default::default()
+        };
+        assert!(validate_limits(&limits).is_err());
+    }
+
+    #[test]
+    fn rejects_zero_sessions() {
+        let limits = LimitsConfig {
+            max_sessions: 0,
+            ..Default::default()
+        };
+        assert!(validate_limits(&limits).is_err());
+    }
+
+    #[test]
+    fn rejects_zero_streams_per_session() {
+        let limits = LimitsConfig {
+            max_streams_per_session: 0,
+            ..Default::default()
+        };
+        assert!(validate_limits(&limits).is_err());
+    }
+
+    #[test]
+    fn rejects_zero_inflight_frames() {
+        let limits = LimitsConfig {
+            max_inflight_frames: 0,
+            ..Default::default()
+        };
+        assert!(validate_limits(&limits).is_err());
+    }
+}

--- a/ferrotunnel-core/src/transport/tls.rs
+++ b/ferrotunnel-core/src/transport/tls.rs
@@ -7,9 +7,17 @@ use rustls::{ClientConfig, RootCertStore, ServerConfig};
 use rustls_pki_types::pem::PemObject;
 use std::io::{self, ErrorKind};
 use std::path::Path;
-use std::sync::Arc;
+use std::sync::{Arc, Once};
 use tokio::net::TcpStream;
 use tokio_rustls::{TlsAcceptor, TlsConnector};
+
+fn install_default_crypto_provider() {
+    static INSTALL: Once = Once::new();
+    INSTALL.call_once(|| {
+        // Err means another process-wide provider is already installed, which is acceptable.
+        let _ = rustls::crypto::ring::default_provider().install_default();
+    });
+}
 
 #[derive(Debug, Clone, Default)]
 pub struct TlsTransportConfig {
@@ -121,6 +129,8 @@ pub(crate) fn create_client_config_with_context(
     transport: &'static str,
     server_name: Option<&str>,
 ) -> io::Result<Arc<ClientConfig>> {
+    install_default_crypto_provider();
+
     let builder = ClientConfig::builder();
 
     let builder = if config.skip_verify {
@@ -169,6 +179,8 @@ fn warn_insecure_verification(transport: &'static str, server_name: Option<&str>
 }
 
 pub fn create_server_config(config: &TlsTransportConfig) -> io::Result<Arc<ServerConfig>> {
+    install_default_crypto_provider();
+
     let certs = load_certs(Path::new(&config.cert_path))?;
     let key = load_private_key(Path::new(&config.key_path))?;
 
@@ -259,5 +271,18 @@ mod tests {
 
         assert!(tls.skip_verify);
         assert_eq!(tls.server_name.as_deref(), Some("localhost"));
+    }
+
+    #[test]
+    fn create_client_config_installs_crypto_provider() {
+        // An embedder that never installs a rustls provider must still be able to
+        // build a client TLS config: the library installs the default provider.
+        // `skip_verify` avoids needing a CA/cert file for this check.
+        let config = TlsTransportConfig {
+            skip_verify: true,
+            ..Default::default()
+        };
+
+        assert!(super::create_client_config(&config).is_ok());
     }
 }

--- a/ferrotunnel-core/src/tunnel/client.rs
+++ b/ferrotunnel-core/src/tunnel/client.rs
@@ -52,6 +52,8 @@ impl TunnelClient {
         self
     }
 
+    /// Set the resource limits used to build the frame codec (frame size and
+    /// control-frame validation bounds).
     #[must_use]
     pub fn with_limits(mut self, limits: LimitsConfig) -> Self {
         self.limits_config = limits;

--- a/ferrotunnel-core/src/tunnel/client.rs
+++ b/ferrotunnel-core/src/tunnel/client.rs
@@ -3,7 +3,7 @@ use crate::stream::{Multiplexer, PrioritizedFrame, VirtualStream};
 use crate::transport::batched_sender::run_batched_sender;
 use crate::transport::{self, TransportConfig};
 use crate::tunnel::common::{clamp_u128_to_u64, read_initial_handshake_frame};
-use ferrotunnel_common::{Result, TunnelError};
+use ferrotunnel_common::{LimitsConfig, Result, TunnelError};
 use ferrotunnel_protocol::codec::TunnelCodec;
 use ferrotunnel_protocol::constants::{MAX_PROTOCOL_VERSION, MIN_PROTOCOL_VERSION};
 use ferrotunnel_protocol::frame::{Frame, HandshakeFrame, HandshakeStatus};
@@ -30,6 +30,7 @@ pub struct TunnelClient {
     tunnel_id: Option<String>,
     transport_config: TransportConfig,
     handshake_timeout: Duration,
+    limits_config: LimitsConfig,
 }
 
 impl TunnelClient {
@@ -41,12 +42,19 @@ impl TunnelClient {
             tunnel_id: None,
             transport_config: TransportConfig::default(),
             handshake_timeout: DEFAULT_HANDSHAKE_TIMEOUT,
+            limits_config: LimitsConfig::default(),
         }
     }
 
     #[must_use]
     pub fn with_transport(mut self, config: TransportConfig) -> Self {
         self.transport_config = config;
+        self
+    }
+
+    #[must_use]
+    pub fn with_limits(mut self, limits: LimitsConfig) -> Self {
+        self.limits_config = limits;
         self
     }
 
@@ -160,7 +168,7 @@ impl TunnelClient {
         let stream = transport::connect(&self.transport_config, &self.server_addr).await?;
         info!("Connected to {}", self.server_addr);
 
-        let mut framed = Framed::new(stream, TunnelCodec::new());
+        let mut framed = Framed::new(stream, TunnelCodec::from_limits(&self.limits_config));
         let session_id = Self::handshake(&mut framed, self, on_connected).await?;
         self.session_id = Some(session_id);
 
@@ -216,10 +224,14 @@ impl TunnelClient {
             .await
             .map_err(|e| TunnelError::Connection(format!("QUIC open control stream: {e}")))?;
 
-        let mut ctrl_framed_send =
-            tokio_util::codec::FramedWrite::new(ctrl_send, TunnelCodec::new());
-        let mut ctrl_framed_recv =
-            tokio_util::codec::FramedRead::new(ctrl_recv, TunnelCodec::new());
+        let mut ctrl_framed_send = tokio_util::codec::FramedWrite::new(
+            ctrl_send,
+            TunnelCodec::from_limits(&self.limits_config),
+        );
+        let mut ctrl_framed_recv = tokio_util::codec::FramedRead::new(
+            ctrl_recv,
+            TunnelCodec::from_limits(&self.limits_config),
+        );
 
         // Handshake
         ctrl_framed_send

--- a/ferrotunnel-core/src/tunnel/client.rs
+++ b/ferrotunnel-core/src/tunnel/client.rs
@@ -163,6 +163,7 @@ impl TunnelClient {
         Fut: Future<Output = ()> + Send + 'static,
         C: FnOnce(Uuid) + Send + 'static,
     {
+        crate::limits::validate_limits(&self.limits_config)?;
         validate_token_format(&self.auth_token, 256)
             .map_err(|e| TunnelError::Authentication(format!("Invalid token: {e}")))?;
 
@@ -206,6 +207,7 @@ impl TunnelClient {
         Fut: Future<Output = ()> + Send + 'static,
         C: FnOnce(Uuid) + Send + 'static,
     {
+        crate::limits::validate_limits(&self.limits_config)?;
         let quic_config = match &self.transport_config {
             TransportConfig::Quic(c) => c.clone(),
             _ => {

--- a/ferrotunnel-core/src/tunnel/server.rs
+++ b/ferrotunnel-core/src/tunnel/server.rs
@@ -6,7 +6,7 @@ use crate::transport::{self, BoxedStream, TransportConfig};
 use crate::tunnel::accept_backoff::{is_transient_accept_error, AcceptBackoff};
 use crate::tunnel::common::{clamp_u128_to_u64, read_initial_handshake_frame};
 use crate::tunnel::session::{Session, SessionStoreBackend, ShardedSessionStore};
-use ferrotunnel_common::{Result, TunnelError};
+use ferrotunnel_common::{LimitsConfig, Result, TunnelError};
 use ferrotunnel_protocol::codec::TunnelCodec;
 use ferrotunnel_protocol::constants::{MAX_PROTOCOL_VERSION, MIN_PROTOCOL_VERSION};
 use ferrotunnel_protocol::frame::{CloseReason, Frame, HandshakeFrame, HandshakeStatus};
@@ -45,6 +45,7 @@ pub struct TunnelServer {
     /// guarded so exactly one cleanup loop runs per server instance even if both
     /// `run` and `run_quic` are invoked.
     cleanup_handle: Option<tokio::task::JoinHandle<()>>,
+    limits_config: LimitsConfig,
 }
 
 impl Drop for TunnelServer {
@@ -68,6 +69,7 @@ impl TunnelServer {
             resource_limits: ServerResourceLimits::default(),
             transport_config: TransportConfig::default(),
             cleanup_handle: None,
+            limits_config: LimitsConfig::default(),
         }
     }
 
@@ -87,6 +89,12 @@ impl TunnelServer {
     #[must_use]
     pub fn with_handshake_timeout(mut self, timeout: Duration) -> Self {
         self.handshake_timeout = timeout;
+        self
+    }
+
+    #[must_use]
+    pub fn with_limits(mut self, limits: LimitsConfig) -> Self {
+        self.limits_config = limits;
         self
     }
 
@@ -225,6 +233,7 @@ impl TunnelServer {
 
             let sessions = sessions.clone();
             let token = self.auth_token.clone();
+            let limits = self.limits_config.clone();
 
             tokio::spawn(async move {
                 if let Err(e) = Self::handle_connection(
@@ -234,6 +243,7 @@ impl TunnelServer {
                     token,
                     session_permit,
                     handshake_timeout,
+                    limits,
                 )
                 .await
                 {
@@ -251,8 +261,9 @@ impl TunnelServer {
         expected_token: String,
         _session_permit: SessionPermit,
         handshake_timeout: Duration,
+        limits_config: LimitsConfig,
     ) -> Result<()> {
-        let mut framed = Framed::new(stream, TunnelCodec::new());
+        let mut framed = Framed::new(stream, TunnelCodec::from_limits(&limits_config));
 
         // 1. Handshake
         let frame = read_initial_handshake_frame(&mut framed, handshake_timeout, "server").await?;
@@ -502,6 +513,7 @@ impl TunnelServer {
 
             let sessions = sessions.clone();
             let token = self.auth_token.clone();
+            let limits = self.limits_config.clone();
 
             tokio::spawn(async move {
                 if let Err(e) = Self::handle_quic_connection(
@@ -511,6 +523,7 @@ impl TunnelServer {
                     token,
                     session_permit,
                     handshake_timeout,
+                    limits,
                 )
                 .await
                 {
@@ -532,6 +545,7 @@ impl TunnelServer {
         expected_token: String,
         _session_permit: SessionPermit,
         handshake_timeout: Duration,
+        limits_config: LimitsConfig,
     ) -> Result<()> {
         // Accept the control stream (first bidi stream opened by client)
         let (ctrl_send, ctrl_recv) = match timeout(handshake_timeout, connection.accept_bi()).await
@@ -551,9 +565,11 @@ impl TunnelServer {
         };
 
         let mut ctrl_framed_recv =
-            tokio_util::codec::FramedRead::new(ctrl_recv, TunnelCodec::new());
-        let mut ctrl_framed_send =
-            tokio_util::codec::FramedWrite::new(ctrl_send, TunnelCodec::new());
+            tokio_util::codec::FramedRead::new(ctrl_recv, TunnelCodec::from_limits(&limits_config));
+        let mut ctrl_framed_send = tokio_util::codec::FramedWrite::new(
+            ctrl_send,
+            TunnelCodec::from_limits(&limits_config),
+        );
 
         // 1. Handshake on control stream
         let frame = match read_initial_handshake_frame(
@@ -835,6 +851,7 @@ mod tests {
             "token".to_string(),
             permit,
             Duration::from_millis(1),
+            LimitsConfig::default(),
         )
         .await
         .unwrap_err();

--- a/ferrotunnel-core/src/tunnel/server.rs
+++ b/ferrotunnel-core/src/tunnel/server.rs
@@ -186,6 +186,7 @@ impl TunnelServer {
     }
 
     pub async fn run(mut self) -> Result<()> {
+        crate::limits::validate_limits(&self.limits_config)?;
         let listener = TcpListener::bind(self.addr).await?;
         info!("Server listening on {}", self.addr);
 
@@ -459,6 +460,7 @@ impl TunnelServer {
     /// This is separate from `run()` which uses TCP. Both can run simultaneously
     /// on different ports.
     pub async fn run_quic(mut self, quic_addr: SocketAddr) -> Result<()> {
+        crate::limits::validate_limits(&self.limits_config)?;
         let quic_config = match &self.transport_config {
             TransportConfig::Quic(c) => c.clone(),
             _ => {

--- a/ferrotunnel-core/src/tunnel/server.rs
+++ b/ferrotunnel-core/src/tunnel/server.rs
@@ -92,6 +92,8 @@ impl TunnelServer {
         self
     }
 
+    /// Set the resource limits used to build the frame codec (frame size and
+    /// control-frame validation bounds).
     #[must_use]
     pub fn with_limits(mut self, limits: LimitsConfig) -> Self {
         self.limits_config = limits;

--- a/ferrotunnel-http/Cargo.toml
+++ b/ferrotunnel-http/Cargo.toml
@@ -12,10 +12,10 @@ categories = ["network-programming", "web-programming"]
 description = "HTTP ingress and proxy implementation for FerroTunnel"
 
 [dependencies]
-ferrotunnel-core = { version = "1.3.0", path = "../ferrotunnel-core" }
-ferrotunnel-protocol = { version = "1.3.0", path = "../ferrotunnel-protocol" }
-ferrotunnel-plugin = { version = "1.3.0", path = "../ferrotunnel-plugin" }
-ferrotunnel-common = { version = "1.3.0", path = "../ferrotunnel-common" }
+ferrotunnel-core = { version = "1.4.0", path = "../ferrotunnel-core" }
+ferrotunnel-protocol = { version = "1.4.0", path = "../ferrotunnel-protocol" }
+ferrotunnel-plugin = { version = "1.4.0", path = "../ferrotunnel-plugin" }
+ferrotunnel-common = { version = "1.4.0", path = "../ferrotunnel-common" }
 tokio = { workspace = true }
 hyper = { version = "1", features = ["full", "http2"] }
 http-body-util = "0.1"
@@ -28,7 +28,7 @@ futures = "0.3"
 tower = { version = "0.5", features = ["full"] }
 tower-service = "0.3"
 thiserror = { workspace = true }
-ferrotunnel-observability = { version = "1.3.0", path = "../ferrotunnel-observability", optional = true }
+ferrotunnel-observability = { version = "1.4.0", path = "../ferrotunnel-observability", optional = true }
 h3 = { workspace = true, optional = true }
 h3-quinn = { workspace = true, optional = true }
 quinn = { workspace = true, optional = true }

--- a/ferrotunnel-observability/Cargo.toml
+++ b/ferrotunnel-observability/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["network-programming"]
 include = ["src/**", "Cargo.toml", "README.md"]
 
 [dependencies]
-ferrotunnel-common = { version = "1.3.0", path = "../ferrotunnel-common" }
+ferrotunnel-common = { version = "1.4.0", path = "../ferrotunnel-common" }
 anyhow = { workspace = true }
 
 # Metrics

--- a/ferrotunnel-protocol/Cargo.toml
+++ b/ferrotunnel-protocol/Cargo.toml
@@ -10,6 +10,7 @@ description = "Wire protocol for FerroTunnel reverse tunnel"
 keywords = ["protocol", "tunnel", "networking"]
 
 [dependencies]
+ferrotunnel-common = { version = "1.3.0", path = "../ferrotunnel-common" }
 serde = { workspace = true }
 bincode-next = { workspace = true }
 bytes = { workspace = true }

--- a/ferrotunnel-protocol/Cargo.toml
+++ b/ferrotunnel-protocol/Cargo.toml
@@ -10,7 +10,7 @@ description = "Wire protocol for FerroTunnel reverse tunnel"
 keywords = ["protocol", "tunnel", "networking"]
 
 [dependencies]
-ferrotunnel-common = { version = "1.3.0", path = "../ferrotunnel-common" }
+ferrotunnel-common = { version = "1.4.0", path = "../ferrotunnel-common" }
 serde = { workspace = true }
 bincode-next = { workspace = true }
 bytes = { workspace = true }

--- a/ferrotunnel-protocol/src/codec.rs
+++ b/ferrotunnel-protocol/src/codec.rs
@@ -61,14 +61,14 @@ impl TunnelCodec {
         Self::default()
     }
 
-    /// Enforce the wire-size contract shared by every constructor.
+    /// Enforce the frame-size contract shared by every constructor.
     ///
     /// # Panics
     ///
-    /// Panics if `max_frame_size` is zero or does not fit in the `u32` wire
-    /// length prefix. This is a programmer-error contract: configured limits
-    /// coming from user input are validated (and rejected with an error) at the
-    /// configuration boundary before reaching the codec.
+    /// Panics if `max_frame_size` is zero or exceeds [`MAX_FRAME_SIZE`]. This is
+    /// a programmer-error contract: configured limits coming from user input are
+    /// validated (and rejected with an error) at the configuration boundary
+    /// before reaching the codec.
     #[inline]
     fn assert_frame_size(max_frame_size: usize) {
         assert!(
@@ -76,8 +76,8 @@ impl TunnelCodec {
             "max frame size must be greater than zero"
         );
         assert!(
-            u32::try_from(max_frame_size).is_ok(),
-            "max frame size must fit in the wire length prefix"
+            max_frame_size <= MAX_FRAME_SIZE as usize,
+            "max frame size must not exceed MAX_FRAME_SIZE"
         );
     }
 
@@ -89,10 +89,10 @@ impl TunnelCodec {
     ///
     /// # Panics
     ///
-    /// Panics if `max_frame_size` is zero or does not fit in the `u32` wire
-    /// length prefix. This is a programmer-error contract: user-supplied limits
-    /// are validated and rejected with an error at the configuration boundary
-    /// before reaching the codec.
+    /// Panics if `max_frame_size` is zero or exceeds [`MAX_FRAME_SIZE`], the
+    /// protocol frame ceiling. This is a programmer-error contract: user-supplied
+    /// limits are validated and rejected with an error at the configuration
+    /// boundary before reaching the codec.
     #[inline]
     pub fn with_max_frame_size(max_frame_size: usize) -> Self {
         Self::assert_frame_size(max_frame_size);
@@ -113,8 +113,8 @@ impl TunnelCodec {
     ///
     /// # Panics
     ///
-    /// Panics if `limits.max_frame_bytes` is zero or does not fit in the `u32`
-    /// wire length prefix; see [`TunnelCodec::with_max_frame_size`].
+    /// Panics if `limits.max_frame_bytes` is zero or exceeds [`MAX_FRAME_SIZE`];
+    /// see [`TunnelCodec::with_max_frame_size`].
     #[inline]
     pub fn from_limits(limits: &LimitsConfig) -> Self {
         let Ok(max_frame_size) = usize::try_from(limits.max_frame_bytes) else {
@@ -223,12 +223,24 @@ impl TunnelCodec {
 const CONTROL_DECODE_HEADROOM: usize = 64 * 1024;
 
 /// Decode a bincode-encoded control frame with a fixed allocation limit.
+///
+/// Rejects a payload with trailing bytes after the bincode-encoded frame: a
+/// well-formed control frame consumes its entire body.
 #[inline]
 fn decode_control_frame_with<const LIMIT: usize>(bytes: &[u8]) -> Result<Frame, io::Error> {
     let config = bincode_next::config::standard().with_limit::<LIMIT>();
-    bincode_next::serde::decode_from_slice::<Frame, _>(bytes, config)
-        .map(|(frame, _)| frame)
-        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, format!("Decode error: {e}")))
+    let (frame, consumed) = bincode_next::serde::decode_from_slice::<Frame, _>(bytes, config)
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, format!("Decode error: {e}")))?;
+    if consumed != bytes.len() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "Trailing bytes after control frame: consumed {consumed} of {}",
+                bytes.len()
+            ),
+        ));
+    }
+    Ok(frame)
 }
 
 /// Decode a bincode control frame with the allocation budget bounded to the
@@ -529,6 +541,30 @@ mod tests {
             err.to_string().contains("LimitExceeded"),
             "expected allocation limit to fire before reading, got: {err}"
         );
+    }
+
+    #[test]
+    fn decode_rejects_control_frame_with_trailing_bytes() {
+        // Encode a valid control frame, then append a byte inside the framed
+        // length so the bincode payload has trailing data. Decode must reject it.
+        let mut codec = TunnelCodec::new();
+        let mut buf = BytesMut::new();
+        codec
+            .encode(Frame::Heartbeat { timestamp: 7 }, &mut buf)
+            .expect("encode");
+
+        // Splice one extra payload byte in and bump the length prefix by one.
+        let mut tampered = buf.to_vec();
+        let new_len = u32::from_be_bytes([tampered[0], tampered[1], tampered[2], tampered[3]]) + 1;
+        tampered[0..4].copy_from_slice(&new_len.to_be_bytes());
+        tampered.push(0xFF);
+        let mut framed = BytesMut::from(&tampered[..]);
+
+        let err = codec
+            .decode(&mut framed)
+            .expect_err("trailing bytes must reject");
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+        assert!(err.to_string().contains("Trailing bytes"));
     }
 
     #[test]

--- a/ferrotunnel-protocol/src/codec.rs
+++ b/ferrotunnel-protocol/src/codec.rs
@@ -10,11 +10,13 @@
 use crate::constants::MAX_FRAME_SIZE;
 use crate::frame::{Frame, ZeroCopyFrame};
 use bytes::{Buf, BufMut, BytesMut};
+use ferrotunnel_common::LimitsConfig;
 use std::io;
 use tokio_util::codec::{Decoder, Encoder};
 
 /// Frame header size: 4 bytes length + 1 byte type
 const HEADER_SIZE: usize = 5;
+const MIN_MAX_FRAME_SIZE: usize = 1;
 
 const FRAME_TYPE_CONTROL: u8 = 0x00;
 const FRAME_TYPE_DATA: u8 = 0x01;
@@ -42,9 +44,7 @@ pub struct TunnelCodec {
 
 impl Default for TunnelCodec {
     fn default() -> Self {
-        Self {
-            max_frame_size: MAX_FRAME_SIZE as usize,
-        }
+        Self::with_max_frame_size(MAX_FRAME_SIZE as usize)
     }
 }
 
@@ -58,7 +58,25 @@ impl TunnelCodec {
     /// Create a new codec instance with a custom max frame size
     #[inline]
     pub fn with_max_frame_size(max_frame_size: usize) -> Self {
+        assert!(
+            max_frame_size >= MIN_MAX_FRAME_SIZE,
+            "max frame size must be greater than zero"
+        );
+        assert!(
+            u32::try_from(max_frame_size).is_ok(),
+            "max frame size must fit in the wire length prefix"
+        );
         Self { max_frame_size }
+    }
+
+    /// Create a new codec instance from configured resource limits.
+    #[inline]
+    pub fn from_limits(limits: &LimitsConfig) -> Self {
+        let max_frame_size = match usize::try_from(limits.max_frame_bytes) {
+            Ok(max_frame_size) => max_frame_size,
+            Err(error) => panic!("max frame size must fit in usize: {error}"),
+        };
+        Self::with_max_frame_size(max_frame_size)
     }
 
     /// Get the configured max frame size
@@ -453,6 +471,32 @@ mod tests {
 
         // Should fail validation before trying to read more
         let result = codec.decode(&mut buf);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    #[should_panic(expected = "max frame size must be greater than zero")]
+    fn test_zero_max_frame_size_rejected() {
+        let _codec = TunnelCodec::with_max_frame_size(0);
+    }
+
+    #[test]
+    fn test_from_limits_enforces_configured_frame_size() {
+        let limits = LimitsConfig {
+            max_frame_bytes: 8,
+            ..Default::default()
+        };
+        let mut codec = TunnelCodec::from_limits(&limits);
+        assert_eq!(codec.max_frame_size(), 8);
+        let mut buf = BytesMut::new();
+
+        let frame = Frame::Data {
+            stream_id: 1,
+            data: Bytes::from_static(b"abc"),
+            end_of_stream: false,
+        };
+
+        let result = codec.encode(frame, &mut buf);
         assert!(result.is_err());
     }
 

--- a/ferrotunnel-protocol/src/codec.rs
+++ b/ferrotunnel-protocol/src/codec.rs
@@ -212,6 +212,66 @@ impl TunnelCodec {
     }
 }
 
+/// Headroom added to the physical frame length when sizing the bincode decode
+/// budget.
+///
+/// bincode claims `len * size_of::<T>()` up front for a collection before
+/// decoding its elements, so a valid dense collection of small elements claims
+/// more than its wire size. This covers the largest such backbone a valid
+/// control frame can produce (`max_headers` entries in an `OpenStream`) with
+/// wide margin, so legitimate frames never trip the budget on backbone overhead.
+const CONTROL_DECODE_HEADROOM: usize = 64 * 1024;
+
+/// Decode a bincode-encoded control frame with a fixed allocation limit.
+#[inline]
+fn decode_control_frame_with<const LIMIT: usize>(bytes: &[u8]) -> Result<Frame, io::Error> {
+    let config = bincode_next::config::standard().with_limit::<LIMIT>();
+    bincode_next::serde::decode_from_slice::<Frame, _>(bytes, config)
+        .map(|(frame, _)| frame)
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, format!("Decode error: {e}")))
+}
+
+/// Decode a bincode control frame with the allocation budget bounded to the
+/// physical frame length.
+///
+/// bincode eagerly allocates for a declared string/collection length *before*
+/// confirming those bytes are present, bounded only by the configured decode
+/// limit. A fixed `MAX_FRAME_SIZE` (16 MB) limit therefore lets a physically
+/// tiny frame that declares a huge length force an allocation up to that
+/// ceiling. Since no valid frame can declare more content than its own size
+/// (plus a small, bounded collection backbone — see [`CONTROL_DECODE_HEADROOM`]),
+/// the budget is capped at the next power of two `>= bytes.len() + headroom`
+/// (a fixed ladder, as `with_limit` is const-generic). This keeps a small frame
+/// from forcing a large allocation while still accepting every valid frame;
+/// large allocations then require a proportionally large frame (no
+/// amplification). `bytes.len()` is already bounded to `max_frame_size`
+/// (`<= MAX_FRAME_SIZE`) by the caller.
+fn decode_control_frame(bytes: &[u8]) -> Result<Frame, io::Error> {
+    let budget = bytes
+        .len()
+        .saturating_add(CONTROL_DECODE_HEADROOM)
+        .checked_next_power_of_two()
+        .unwrap_or(MAX_FRAME_SIZE as usize)
+        .min(MAX_FRAME_SIZE as usize);
+    macro_rules! ladder {
+        ($($limit:expr),+ $(,)?) => {
+            match budget {
+                $(b if b <= $limit => decode_control_frame_with::<{ $limit }>(bytes),)+
+                _ => decode_control_frame_with::<{ MAX_FRAME_SIZE as usize }>(bytes),
+            }
+        };
+    }
+    ladder!(
+        1 << 17,
+        1 << 18,
+        1 << 19,
+        1 << 20,
+        1 << 21,
+        1 << 22,
+        1 << 23,
+    )
+}
+
 impl Decoder for TunnelCodec {
     type Item = Frame;
     type Error = io::Error;
@@ -280,19 +340,13 @@ impl Decoder for TunnelCodec {
                 }))
             }
             FRAME_TYPE_CONTROL => {
-                // Control frame: bincode-encoded Frame. The bincode limit is a
-                // compile-time absolute ceiling (`MAX_FRAME_SIZE`); runtime
-                // enforcement is the length-prefix bound checked above plus the
-                // per-variant validation below, which bounds the cardinality and
-                // per-element size of variable-length frame contents.
-                let config =
-                    bincode_next::config::standard().with_limit::<{ MAX_FRAME_SIZE as usize }>();
-                let (frame, _): (Frame, _) =
-                    bincode_next::serde::decode_from_slice(frame_bytes.as_ref(), config).map_err(
-                        |e| {
-                            io::Error::new(io::ErrorKind::InvalidData, format!("Decode error: {e}"))
-                        },
-                    )?;
+                // Control frame: bincode-encoded Frame. Two layers of runtime
+                // enforcement: (1) `decode_control_frame` caps bincode's
+                // allocation budget at the physical frame length so a frame
+                // cannot force an allocation larger than its real size, and
+                // (2) `validate_frame` bounds the cardinality and per-element
+                // size of the decoded frame's variable-length contents.
+                let frame = decode_control_frame(frame_bytes.as_ref())?;
                 validate_frame(&frame, &self.validation).map_err(|e| {
                     io::Error::new(io::ErrorKind::InvalidData, format!("Frame validation: {e}"))
                 })?;
@@ -444,6 +498,37 @@ mod tests {
         let err = codec.decode(&mut buf).expect_err("decode must reject");
         assert_eq!(err.kind(), io::ErrorKind::InvalidData);
         assert!(err.to_string().contains("validation"));
+    }
+
+    #[test]
+    fn decode_bounds_allocation_to_physical_frame_size() {
+        // A 13-byte control frame that declares a 15 MB `Error` message must be
+        // rejected by bincode's allocation limit *before* it allocates, not
+        // after. The decode limit is capped at the physical frame length, so
+        // the declared length trips `LimitExceeded` rather than allocating 15 MB
+        // and then failing with `UnexpectedEnd`.
+        //
+        // Wire bytes: [len prefix = 9][type = CONTROL]
+        //   [disc 10 = Error][Option None][ErrorCode idx 0]
+        //   [message len varint = 15_000_000: 0xFC + u32 LE][no message bytes]
+        let mut buf = BytesMut::from(
+            &[
+                0x00, 0x00, 0x00, 0x09, // length prefix (BE u32) = 9
+                0x00, // FRAME_TYPE_CONTROL
+                0x0A, // enum discriminant 10 = Frame::Error
+                0x00, // stream_id: Option = None
+                0x00, // code: ErrorCode variant index 0
+                0xFC, 0xC0, 0xE1, 0xE4, 0x00, // message len = 15_000_000 (u32 marker)
+            ][..],
+        );
+
+        let mut codec = TunnelCodec::new();
+        let err = codec.decode(&mut buf).expect_err("decode must reject");
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+        assert!(
+            err.to_string().contains("LimitExceeded"),
+            "expected allocation limit to fire before reading, got: {err}"
+        );
     }
 
     #[test]

--- a/ferrotunnel-protocol/src/codec.rs
+++ b/ferrotunnel-protocol/src/codec.rs
@@ -38,6 +38,10 @@ const FLAG_EOS: u8 = 0x01;
 /// Payload format depends on Type:
 /// - Control (0x00): `bincode(Frame)` (excluding `Frame::Data`)
 /// - Data (0x01): `[StreamID(u32)][Flags(u8)][Raw Bytes...]`
+// `Copy` is required, not cosmetic: the tunnel client/server split a `Framed`
+// via `into_parts()` and then read `parts.codec` more than once (for the split
+// reader and for the batched sender). Keep this `Copy` — switching to `Clone`
+// breaks that split-stream pattern.
 #[derive(Debug, Clone, Copy)]
 pub struct TunnelCodec {
     max_frame_size: usize,
@@ -57,7 +61,7 @@ impl TunnelCodec {
         Self::default()
     }
 
-    /// Create a new codec instance with a custom max frame size
+    /// Enforce the wire-size contract shared by every constructor.
     ///
     /// # Panics
     ///
@@ -66,7 +70,7 @@ impl TunnelCodec {
     /// coming from user input are validated (and rejected with an error) at the
     /// configuration boundary before reaching the codec.
     #[inline]
-    pub fn with_max_frame_size(max_frame_size: usize) -> Self {
+    fn assert_frame_size(max_frame_size: usize) {
         assert!(
             max_frame_size >= MIN_MAX_FRAME_SIZE,
             "max frame size must be greater than zero"
@@ -75,6 +79,23 @@ impl TunnelCodec {
             u32::try_from(max_frame_size).is_ok(),
             "max frame size must fit in the wire length prefix"
         );
+    }
+
+    /// Create a new codec instance with a custom max frame size.
+    ///
+    /// Only the byte budget (`max_frame_size`) is set from the argument; the
+    /// per-field cardinality and element-size bounds keep their default floors.
+    /// Use [`TunnelCodec::from_limits`] to derive both from a [`LimitsConfig`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if `max_frame_size` is zero or does not fit in the `u32` wire
+    /// length prefix. This is a programmer-error contract: user-supplied limits
+    /// are validated and rejected with an error at the configuration boundary
+    /// before reaching the codec.
+    #[inline]
+    pub fn with_max_frame_size(max_frame_size: usize) -> Self {
+        Self::assert_frame_size(max_frame_size);
         Self {
             max_frame_size,
             validation: ValidationLimits {
@@ -87,8 +108,8 @@ impl TunnelCodec {
 
     /// Create a new codec instance from configured resource limits.
     ///
-    /// The configured limits also bound the cardinality and per-element size of
-    /// control-frame contents enforced during [`Decoder::decode`].
+    /// Both the byte budget and the per-field cardinality/element-size bounds
+    /// enforced during [`Decoder::decode`] are derived from `limits`.
     ///
     /// # Panics
     ///
@@ -96,13 +117,14 @@ impl TunnelCodec {
     /// wire length prefix; see [`TunnelCodec::with_max_frame_size`].
     #[inline]
     pub fn from_limits(limits: &LimitsConfig) -> Self {
-        let max_frame_size = match usize::try_from(limits.max_frame_bytes) {
-            Ok(max_frame_size) => max_frame_size,
-            Err(error) => panic!("max frame size must fit in usize: {error}"),
+        let Ok(max_frame_size) = usize::try_from(limits.max_frame_bytes) else {
+            panic!("max frame size must fit in usize")
         };
-        let mut codec = Self::with_max_frame_size(max_frame_size);
-        codec.validation = ValidationLimits::from(limits);
-        codec
+        Self::assert_frame_size(max_frame_size);
+        Self {
+            max_frame_size,
+            validation: ValidationLimits::from(limits),
+        }
     }
 
     /// Get the configured max frame size
@@ -387,6 +409,32 @@ mod tests {
             protocol: crate::frame::Protocol::HTTP,
             metadata,
         };
+
+        let mut buf = BytesMut::new();
+        codec
+            .encode(frame, &mut buf)
+            .expect("encode fits in frame size");
+
+        let err = codec.decode(&mut buf).expect_err("decode must reject");
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+        assert!(err.to_string().contains("validation"));
+    }
+
+    #[test]
+    fn decode_rejects_oversized_openstream_headers() {
+        // An `OpenStream` that fits the frame-size budget but carries an abusive
+        // number of headers must be rejected by the decode path.
+        let mut codec = TunnelCodec::new();
+        let headers = (0..1000)
+            .map(|i| (format!("h{i}"), "v".to_string()))
+            .collect();
+        let frame = Frame::OpenStream(Box::new(crate::frame::OpenStreamFrame {
+            stream_id: 1,
+            protocol: crate::frame::Protocol::HTTP,
+            headers,
+            body_hint: None,
+            priority: crate::frame::StreamPriority::default(),
+        }));
 
         let mut buf = BytesMut::new();
         codec

--- a/ferrotunnel-protocol/src/codec.rs
+++ b/ferrotunnel-protocol/src/codec.rs
@@ -9,6 +9,7 @@
 
 use crate::constants::MAX_FRAME_SIZE;
 use crate::frame::{Frame, ZeroCopyFrame};
+use crate::validation::{validate_frame, ValidationLimits};
 use bytes::{Buf, BufMut, BytesMut};
 use ferrotunnel_common::LimitsConfig;
 use std::io;
@@ -40,6 +41,7 @@ const FLAG_EOS: u8 = 0x01;
 #[derive(Debug, Clone, Copy)]
 pub struct TunnelCodec {
     max_frame_size: usize,
+    validation: ValidationLimits,
 }
 
 impl Default for TunnelCodec {
@@ -56,6 +58,13 @@ impl TunnelCodec {
     }
 
     /// Create a new codec instance with a custom max frame size
+    ///
+    /// # Panics
+    ///
+    /// Panics if `max_frame_size` is zero or does not fit in the `u32` wire
+    /// length prefix. This is a programmer-error contract: configured limits
+    /// coming from user input are validated (and rejected with an error) at the
+    /// configuration boundary before reaching the codec.
     #[inline]
     pub fn with_max_frame_size(max_frame_size: usize) -> Self {
         assert!(
@@ -66,17 +75,34 @@ impl TunnelCodec {
             u32::try_from(max_frame_size).is_ok(),
             "max frame size must fit in the wire length prefix"
         );
-        Self { max_frame_size }
+        Self {
+            max_frame_size,
+            validation: ValidationLimits {
+                max_frame_bytes: max_frame_size as u64,
+                max_payload_bytes: max_frame_size,
+                ..ValidationLimits::default()
+            },
+        }
     }
 
     /// Create a new codec instance from configured resource limits.
+    ///
+    /// The configured limits also bound the cardinality and per-element size of
+    /// control-frame contents enforced during [`Decoder::decode`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if `limits.max_frame_bytes` is zero or does not fit in the `u32`
+    /// wire length prefix; see [`TunnelCodec::with_max_frame_size`].
     #[inline]
     pub fn from_limits(limits: &LimitsConfig) -> Self {
         let max_frame_size = match usize::try_from(limits.max_frame_bytes) {
             Ok(max_frame_size) => max_frame_size,
             Err(error) => panic!("max frame size must fit in usize: {error}"),
         };
-        Self::with_max_frame_size(max_frame_size)
+        let mut codec = Self::with_max_frame_size(max_frame_size);
+        codec.validation = ValidationLimits::from(limits);
+        codec
     }
 
     /// Get the configured max frame size
@@ -232,15 +258,22 @@ impl Decoder for TunnelCodec {
                 }))
             }
             FRAME_TYPE_CONTROL => {
-                // Control frame: bincode-encoded Frame
+                // Control frame: bincode-encoded Frame. The bincode limit is a
+                // compile-time absolute ceiling (`MAX_FRAME_SIZE`); runtime
+                // enforcement is the length-prefix bound checked above plus the
+                // per-variant validation below, which bounds the cardinality and
+                // per-element size of variable-length frame contents.
                 let config =
                     bincode_next::config::standard().with_limit::<{ MAX_FRAME_SIZE as usize }>();
-                let (frame, _) =
+                let (frame, _): (Frame, _) =
                     bincode_next::serde::decode_from_slice(frame_bytes.as_ref(), config).map_err(
                         |e| {
                             io::Error::new(io::ErrorKind::InvalidData, format!("Decode error: {e}"))
                         },
                     )?;
+                validate_frame(&frame, &self.validation).map_err(|e| {
+                    io::Error::new(io::ErrorKind::InvalidData, format!("Frame validation: {e}"))
+                })?;
                 Ok(Some(frame))
             }
             _ => Err(io::Error::new(
@@ -338,6 +371,31 @@ mod tests {
         let decoded = codec.decode(&mut buf).unwrap().unwrap();
 
         assert_eq!(frame, decoded);
+    }
+
+    #[test]
+    fn decode_rejects_oversized_register_metadata() {
+        // A `Register` that fits the frame-size budget but carries an abusive
+        // number of metadata entries must be rejected by the decode path.
+        let mut codec = TunnelCodec::new();
+        let mut metadata = std::collections::HashMap::new();
+        for i in 0..1000 {
+            metadata.insert(format!("k{i}"), "v".to_string());
+        }
+        let frame = Frame::Register {
+            service_name: "svc".into(),
+            protocol: crate::frame::Protocol::HTTP,
+            metadata,
+        };
+
+        let mut buf = BytesMut::new();
+        codec
+            .encode(frame, &mut buf)
+            .expect("encode fits in frame size");
+
+        let err = codec.decode(&mut buf).expect_err("decode must reject");
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+        assert!(err.to_string().contains("validation"));
     }
 
     #[test]

--- a/ferrotunnel-protocol/src/validation.rs
+++ b/ferrotunnel-protocol/src/validation.rs
@@ -185,7 +185,9 @@ pub fn validate_frame(frame: &Frame, limits: &ValidationLimits) -> Result<(), Va
             server_capabilities,
             ..
         } => validate_capabilities(server_capabilities, limits),
-        Frame::RegisterAck { public_url, .. } => check_field_len(public_url.len(), limits.max_url_len),
+        Frame::RegisterAck { public_url, .. } => {
+            check_field_len(public_url.len(), limits.max_url_len)
+        }
         Frame::Data { data, .. } => validate_payload(data.len(), limits),
         Frame::Register {
             service_name,
@@ -193,7 +195,9 @@ pub fn validate_frame(frame: &Frame, limits: &ValidationLimits) -> Result<(), Va
             ..
         } => validate_register(service_name, metadata, limits),
         Frame::OpenStream(open) => validate_open_stream(open, limits),
-        Frame::Error { message, .. } => check_field_len(message.len(), limits.max_error_message_len),
+        Frame::Error { message, .. } => {
+            check_field_len(message.len(), limits.max_error_message_len)
+        }
         Frame::PluginData { plugin_id, data } => {
             check_field_len(plugin_id.len(), limits.max_name_len)?;
             validate_payload(data.len(), limits)

--- a/ferrotunnel-protocol/src/validation.rs
+++ b/ferrotunnel-protocol/src/validation.rs
@@ -1,6 +1,7 @@
 //! Frame validation for security hardening
 
 use crate::frame::Frame;
+use ferrotunnel_common::LimitsConfig;
 
 /// Validation errors
 #[derive(Debug, thiserror::Error)]
@@ -33,12 +34,18 @@ pub struct ValidationLimits {
 
 impl Default for ValidationLimits {
     fn default() -> Self {
+        Self::from(&LimitsConfig::default())
+    }
+}
+
+impl From<&LimitsConfig> for ValidationLimits {
+    fn from(limits: &LimitsConfig) -> Self {
         Self {
-            max_frame_bytes: 16 * 1024 * 1024,
-            max_token_len: 256,
-            max_capabilities: 32,
-            max_capability_len: 64,
-            max_payload_bytes: 16 * 1024 * 1024,
+            max_frame_bytes: limits.max_frame_bytes,
+            max_token_len: limits.max_token_len,
+            max_capabilities: limits.max_capabilities,
+            max_capability_len: limits.max_capability_len,
+            max_payload_bytes: usize::try_from(limits.max_frame_bytes).unwrap_or(usize::MAX),
         }
     }
 }
@@ -96,4 +103,27 @@ pub fn validate_frame(frame: &Frame, limits: &ValidationLimits) -> Result<(), Va
         _ => {}
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_validation_limits_from_limits_config() {
+        let limits = LimitsConfig {
+            max_frame_bytes: 4096,
+            max_token_len: 32,
+            max_capabilities: 4,
+            max_capability_len: 16,
+            ..Default::default()
+        };
+        let validation = ValidationLimits::from(&limits);
+
+        assert_eq!(validation.max_frame_bytes, 4096);
+        assert_eq!(validation.max_payload_bytes, 4096);
+        assert_eq!(validation.max_token_len, 32);
+        assert_eq!(validation.max_capabilities, 4);
+        assert_eq!(validation.max_capability_len, 16);
+    }
 }

--- a/ferrotunnel-protocol/src/validation.rs
+++ b/ferrotunnel-protocol/src/validation.rs
@@ -1,6 +1,6 @@
 //! Frame validation for security hardening
 
-use crate::frame::{Frame, OpenStreamFrame};
+use crate::frame::{CloseReason, Frame, OpenStreamFrame};
 use ferrotunnel_common::LimitsConfig;
 use std::collections::HashMap;
 
@@ -29,6 +29,21 @@ pub enum ValidationError {
     FieldTooLong { len: usize, limit: usize },
 }
 
+/// Default cardinality and per-element size floors for control-frame contents.
+///
+/// These are fixed security floors for this release rather than operator-tunable
+/// knobs: `LimitsConfig` exposes only the frame/session budgets, and these
+/// per-field bounds are derived from those plus the constants below. Promoting
+/// them to `LimitsConfig` is deferred to the public-API-surface work in a later
+/// milestone.
+const DEFAULT_MAX_METADATA_ENTRIES: usize = 64;
+const DEFAULT_MAX_NAME_LEN: usize = 256;
+const DEFAULT_MAX_METADATA_VALUE_LEN: usize = 1024;
+const DEFAULT_MAX_HEADERS: usize = 128;
+const DEFAULT_MAX_HEADER_LEN: usize = 8 * 1024;
+const DEFAULT_MAX_ERROR_MESSAGE_LEN: usize = 4 * 1024;
+const DEFAULT_MAX_URL_LEN: usize = 2 * 1024;
+
 /// Validation limits
 ///
 /// The wire length-prefix already caps the encoded size of a frame at
@@ -36,6 +51,11 @@ pub enum ValidationError {
 /// *per-element size* of variable-length frame contents, so that a frame which
 /// fits the byte budget cannot still force allocation amplification (for
 /// example a `Register` packed with many tiny metadata entries).
+///
+/// The `max_frame_bytes`, `max_payload_bytes`, `max_token_len`,
+/// `max_capabilities`, and `max_capability_len` fields track `LimitsConfig`; the
+/// remaining per-field bounds are fixed defaults (see the `DEFAULT_MAX_*`
+/// constants) applied uniformly regardless of the configured frame budget.
 #[derive(Debug, Clone, Copy)]
 pub struct ValidationLimits {
     pub max_frame_bytes: u64,
@@ -73,13 +93,13 @@ impl From<&LimitsConfig> for ValidationLimits {
             max_capabilities: limits.max_capabilities,
             max_capability_len: limits.max_capability_len,
             max_payload_bytes: usize::try_from(limits.max_frame_bytes).unwrap_or(usize::MAX),
-            max_metadata_entries: limits.max_capabilities.max(64),
-            max_name_len: 256,
-            max_metadata_value_len: 1024,
-            max_headers: 128,
-            max_header_len: 8 * 1024,
-            max_error_message_len: 4 * 1024,
-            max_url_len: 2 * 1024,
+            max_metadata_entries: DEFAULT_MAX_METADATA_ENTRIES,
+            max_name_len: DEFAULT_MAX_NAME_LEN,
+            max_metadata_value_len: DEFAULT_MAX_METADATA_VALUE_LEN,
+            max_headers: DEFAULT_MAX_HEADERS,
+            max_header_len: DEFAULT_MAX_HEADER_LEN,
+            max_error_message_len: DEFAULT_MAX_ERROR_MESSAGE_LEN,
+            max_url_len: DEFAULT_MAX_URL_LEN,
         }
     }
 }
@@ -176,8 +196,10 @@ fn validate_payload(len: usize, limits: &ValidationLimits) -> Result<(), Validat
 
 /// Validate a decoded frame against limits.
 ///
-/// Every variant carrying variable-length content is bounded on cardinality and
-/// per-element size; variants with only fixed-size fields are always accepted.
+/// Every variant carrying variable-length content — including the `String`
+/// payload of `CloseReason::Error` inside `CloseStream` — is bounded on
+/// cardinality and per-element size; variants whose fields are all fixed-size
+/// are always accepted.
 pub fn validate_frame(frame: &Frame, limits: &ValidationLimits) -> Result<(), ValidationError> {
     match frame {
         Frame::Handshake(handshake) => validate_handshake(handshake, limits),
@@ -198,6 +220,10 @@ pub fn validate_frame(frame: &Frame, limits: &ValidationLimits) -> Result<(), Va
         Frame::Error { message, .. } => {
             check_field_len(message.len(), limits.max_error_message_len)
         }
+        Frame::CloseStream {
+            reason: CloseReason::Error(message),
+            ..
+        } => check_field_len(message.len(), limits.max_error_message_len),
         Frame::PluginData { plugin_id, data } => {
             check_field_len(plugin_id.len(), limits.max_name_len)?;
             validate_payload(data.len(), limits)
@@ -303,5 +329,28 @@ mod tests {
             validate_frame(&frame, &limits),
             Err(ValidationError::FieldTooLong { .. })
         ));
+    }
+
+    #[test]
+    fn rejects_close_stream_with_oversized_error_reason() {
+        let limits = ValidationLimits::default();
+        let frame = Frame::CloseStream {
+            stream_id: 1,
+            reason: CloseReason::Error("x".repeat(limits.max_error_message_len + 1)),
+        };
+        assert!(matches!(
+            validate_frame(&frame, &limits),
+            Err(ValidationError::FieldTooLong { .. })
+        ));
+    }
+
+    #[test]
+    fn accepts_close_stream_without_error_reason() {
+        let limits = ValidationLimits::default();
+        let frame = Frame::CloseStream {
+            stream_id: 1,
+            reason: CloseReason::Normal,
+        };
+        assert!(validate_frame(&frame, &limits).is_ok());
     }
 }

--- a/ferrotunnel-protocol/src/validation.rs
+++ b/ferrotunnel-protocol/src/validation.rs
@@ -1,7 +1,8 @@
 //! Frame validation for security hardening
 
-use crate::frame::Frame;
+use crate::frame::{Frame, OpenStreamFrame};
 use ferrotunnel_common::LimitsConfig;
+use std::collections::HashMap;
 
 /// Validation errors
 #[derive(Debug, thiserror::Error)]
@@ -20,16 +21,42 @@ pub enum ValidationError {
 
     #[error("Payload too large: {size} bytes exceeds limit of {limit} bytes")]
     PayloadTooLarge { size: usize, limit: usize },
+
+    #[error("Too many entries: {count} exceeds limit of {limit}")]
+    TooManyEntries { count: usize, limit: usize },
+
+    #[error("Field too long: {len} bytes exceeds limit of {limit} bytes")]
+    FieldTooLong { len: usize, limit: usize },
 }
 
 /// Validation limits
-#[derive(Debug, Clone)]
+///
+/// The wire length-prefix already caps the encoded size of a frame at
+/// `max_frame_bytes`. These limits additionally bound the *cardinality* and
+/// *per-element size* of variable-length frame contents, so that a frame which
+/// fits the byte budget cannot still force allocation amplification (for
+/// example a `Register` packed with many tiny metadata entries).
+#[derive(Debug, Clone, Copy)]
 pub struct ValidationLimits {
     pub max_frame_bytes: u64,
     pub max_token_len: usize,
     pub max_capabilities: usize,
     pub max_capability_len: usize,
     pub max_payload_bytes: usize,
+    /// Maximum number of entries in a `Register` metadata map.
+    pub max_metadata_entries: usize,
+    /// Maximum byte length of a metadata key, a service name, or a plugin id.
+    pub max_name_len: usize,
+    /// Maximum byte length of a metadata value.
+    pub max_metadata_value_len: usize,
+    /// Maximum number of headers in an `OpenStream` frame.
+    pub max_headers: usize,
+    /// Maximum byte length of a single header name or value.
+    pub max_header_len: usize,
+    /// Maximum byte length of an `Error` frame message.
+    pub max_error_message_len: usize,
+    /// Maximum byte length of a public URL in a `RegisterAck` frame.
+    pub max_url_len: usize,
 }
 
 impl Default for ValidationLimits {
@@ -46,63 +73,133 @@ impl From<&LimitsConfig> for ValidationLimits {
             max_capabilities: limits.max_capabilities,
             max_capability_len: limits.max_capability_len,
             max_payload_bytes: usize::try_from(limits.max_frame_bytes).unwrap_or(usize::MAX),
+            max_metadata_entries: limits.max_capabilities.max(64),
+            max_name_len: 256,
+            max_metadata_value_len: 1024,
+            max_headers: 128,
+            max_header_len: 8 * 1024,
+            max_error_message_len: 4 * 1024,
+            max_url_len: 2 * 1024,
         }
     }
 }
 
-/// Validate a decoded frame against limits
+/// Reject a variable-length field whose byte length exceeds `limit`.
+fn check_field_len(len: usize, limit: usize) -> Result<(), ValidationError> {
+    if len > limit {
+        return Err(ValidationError::FieldTooLong { len, limit });
+    }
+    Ok(())
+}
+
+/// Reject a collection whose entry count exceeds `limit`.
+fn check_entry_count(count: usize, limit: usize) -> Result<(), ValidationError> {
+    if count > limit {
+        return Err(ValidationError::TooManyEntries { count, limit });
+    }
+    Ok(())
+}
+
+/// Validate a capability list shared by `Handshake` and `HandshakeAck`.
+fn validate_capabilities(
+    capabilities: &[String],
+    limits: &ValidationLimits,
+) -> Result<(), ValidationError> {
+    if capabilities.len() > limits.max_capabilities {
+        return Err(ValidationError::TooManyCapabilities {
+            count: capabilities.len(),
+            limit: limits.max_capabilities,
+        });
+    }
+    for cap in capabilities {
+        if cap.len() > limits.max_capability_len {
+            return Err(ValidationError::CapabilityTooLong {
+                len: cap.len(),
+                limit: limits.max_capability_len,
+            });
+        }
+    }
+    Ok(())
+}
+
+fn validate_handshake(
+    handshake: &crate::frame::HandshakeFrame,
+    limits: &ValidationLimits,
+) -> Result<(), ValidationError> {
+    if handshake.token.len() > limits.max_token_len {
+        return Err(ValidationError::TokenTooLong {
+            len: handshake.token.len(),
+            limit: limits.max_token_len,
+        });
+    }
+    if let Some(tunnel_id) = &handshake.tunnel_id {
+        check_field_len(tunnel_id.len(), limits.max_name_len)?;
+    }
+    validate_capabilities(&handshake.capabilities, limits)
+}
+
+fn validate_register(
+    service_name: &str,
+    metadata: &HashMap<String, String>,
+    limits: &ValidationLimits,
+) -> Result<(), ValidationError> {
+    check_field_len(service_name.len(), limits.max_name_len)?;
+    check_entry_count(metadata.len(), limits.max_metadata_entries)?;
+    for (key, value) in metadata {
+        check_field_len(key.len(), limits.max_name_len)?;
+        check_field_len(value.len(), limits.max_metadata_value_len)?;
+    }
+    Ok(())
+}
+
+fn validate_open_stream(
+    open: &OpenStreamFrame,
+    limits: &ValidationLimits,
+) -> Result<(), ValidationError> {
+    check_entry_count(open.headers.len(), limits.max_headers)?;
+    for (name, value) in &open.headers {
+        check_field_len(name.len(), limits.max_header_len)?;
+        check_field_len(value.len(), limits.max_header_len)?;
+    }
+    Ok(())
+}
+
+fn validate_payload(len: usize, limits: &ValidationLimits) -> Result<(), ValidationError> {
+    if len > limits.max_payload_bytes {
+        return Err(ValidationError::PayloadTooLarge {
+            size: len,
+            limit: limits.max_payload_bytes,
+        });
+    }
+    Ok(())
+}
+
+/// Validate a decoded frame against limits.
+///
+/// Every variant carrying variable-length content is bounded on cardinality and
+/// per-element size; variants with only fixed-size fields are always accepted.
 pub fn validate_frame(frame: &Frame, limits: &ValidationLimits) -> Result<(), ValidationError> {
     match frame {
-        Frame::Handshake(handshake) => {
-            if handshake.token.len() > limits.max_token_len {
-                return Err(ValidationError::TokenTooLong {
-                    len: handshake.token.len(),
-                    limit: limits.max_token_len,
-                });
-            }
-            if handshake.capabilities.len() > limits.max_capabilities {
-                return Err(ValidationError::TooManyCapabilities {
-                    count: handshake.capabilities.len(),
-                    limit: limits.max_capabilities,
-                });
-            }
-            for cap in &handshake.capabilities {
-                if cap.len() > limits.max_capability_len {
-                    return Err(ValidationError::CapabilityTooLong {
-                        len: cap.len(),
-                        limit: limits.max_capability_len,
-                    });
-                }
-            }
-        }
+        Frame::Handshake(handshake) => validate_handshake(handshake, limits),
         Frame::HandshakeAck {
             server_capabilities,
             ..
-        } => {
-            if server_capabilities.len() > limits.max_capabilities {
-                return Err(ValidationError::TooManyCapabilities {
-                    count: server_capabilities.len(),
-                    limit: limits.max_capabilities,
-                });
-            }
-            for cap in server_capabilities {
-                if cap.len() > limits.max_capability_len {
-                    return Err(ValidationError::CapabilityTooLong {
-                        len: cap.len(),
-                        limit: limits.max_capability_len,
-                    });
-                }
-            }
+        } => validate_capabilities(server_capabilities, limits),
+        Frame::RegisterAck { public_url, .. } => check_field_len(public_url.len(), limits.max_url_len),
+        Frame::Data { data, .. } => validate_payload(data.len(), limits),
+        Frame::Register {
+            service_name,
+            metadata,
+            ..
+        } => validate_register(service_name, metadata, limits),
+        Frame::OpenStream(open) => validate_open_stream(open, limits),
+        Frame::Error { message, .. } => check_field_len(message.len(), limits.max_error_message_len),
+        Frame::PluginData { plugin_id, data } => {
+            check_field_len(plugin_id.len(), limits.max_name_len)?;
+            validate_payload(data.len(), limits)
         }
-        Frame::Data { data, .. } if data.len() > limits.max_payload_bytes => {
-            return Err(ValidationError::PayloadTooLarge {
-                size: data.len(),
-                limit: limits.max_payload_bytes,
-            });
-        }
-        _ => {}
+        _ => Ok(()),
     }
-    Ok(())
 }
 
 #[cfg(test)]
@@ -125,5 +222,82 @@ mod tests {
         assert_eq!(validation.max_token_len, 32);
         assert_eq!(validation.max_capabilities, 4);
         assert_eq!(validation.max_capability_len, 16);
+    }
+
+    #[test]
+    fn rejects_register_with_oversized_metadata_map() {
+        let limits = ValidationLimits::default();
+        let mut metadata = HashMap::new();
+        for i in 0..=limits.max_metadata_entries {
+            metadata.insert(format!("k{i}"), "v".to_string());
+        }
+        let frame = Frame::Register {
+            service_name: "svc".into(),
+            protocol: crate::frame::Protocol::HTTP,
+            metadata,
+        };
+        assert!(matches!(
+            validate_frame(&frame, &limits),
+            Err(ValidationError::TooManyEntries { .. })
+        ));
+    }
+
+    #[test]
+    fn rejects_openstream_with_too_many_headers() {
+        let limits = ValidationLimits::default();
+        let headers = (0..=limits.max_headers)
+            .map(|i| (format!("h{i}"), "v".to_string()))
+            .collect();
+        let frame = Frame::OpenStream(Box::new(OpenStreamFrame {
+            stream_id: 1,
+            protocol: crate::frame::Protocol::HTTP,
+            headers,
+            body_hint: None,
+            priority: crate::frame::StreamPriority::default(),
+        }));
+        assert!(matches!(
+            validate_frame(&frame, &limits),
+            Err(ValidationError::TooManyEntries { .. })
+        ));
+    }
+
+    #[test]
+    fn accepts_well_formed_register() {
+        let limits = ValidationLimits::default();
+        let frame = Frame::Register {
+            service_name: "svc".into(),
+            protocol: crate::frame::Protocol::HTTP,
+            metadata: HashMap::new(),
+        };
+        assert!(validate_frame(&frame, &limits).is_ok());
+    }
+
+    #[test]
+    fn rejects_registerack_with_oversized_url() {
+        let limits = ValidationLimits::default();
+        let frame = Frame::RegisterAck {
+            public_url: "x".repeat(limits.max_url_len + 1),
+            status: crate::frame::RegisterStatus::Success,
+        };
+        assert!(matches!(
+            validate_frame(&frame, &limits),
+            Err(ValidationError::FieldTooLong { .. })
+        ));
+    }
+
+    #[test]
+    fn rejects_handshake_with_oversized_tunnel_id() {
+        let limits = ValidationLimits::default();
+        let frame = Frame::Handshake(Box::new(crate::frame::HandshakeFrame {
+            token: "t".into(),
+            tunnel_id: Some("x".repeat(limits.max_name_len + 1)),
+            min_version: 1,
+            max_version: 1,
+            capabilities: Vec::new(),
+        }));
+        assert!(matches!(
+            validate_frame(&frame, &limits),
+            Err(ValidationError::FieldTooLong { .. })
+        ));
     }
 }

--- a/ferrotunnel-protocol/src/validation.rs
+++ b/ferrotunnel-protocol/src/validation.rs
@@ -194,12 +194,27 @@ fn validate_payload(len: usize, limits: &ValidationLimits) -> Result<(), Validat
     Ok(())
 }
 
+/// Validate the only variable-length `CloseReason`; other reasons are fixed-size.
+fn validate_close_reason(
+    reason: &CloseReason,
+    limits: &ValidationLimits,
+) -> Result<(), ValidationError> {
+    match reason {
+        CloseReason::Error(message) => check_field_len(message.len(), limits.max_error_message_len),
+        CloseReason::Normal
+        | CloseReason::Timeout
+        | CloseReason::LocalServiceUnreachable
+        | CloseReason::ProtocolViolation => Ok(()),
+    }
+}
+
 /// Validate a decoded frame against limits.
 ///
-/// Every variant carrying variable-length content — including the `String`
-/// payload of `CloseReason::Error` inside `CloseStream` — is bounded on
-/// cardinality and per-element size; variants whose fields are all fixed-size
-/// are always accepted.
+/// The match is exhaustive (no wildcard) so that adding a `Frame` or
+/// `CloseReason` variant fails to compile until a validation decision is made
+/// here. Variants carrying variable-length content are bounded on cardinality
+/// and per-element size; variants whose fields are all fixed-size accept
+/// unconditionally.
 pub fn validate_frame(frame: &Frame, limits: &ValidationLimits) -> Result<(), ValidationError> {
     match frame {
         Frame::Handshake(handshake) => validate_handshake(handshake, limits),
@@ -207,28 +222,25 @@ pub fn validate_frame(frame: &Frame, limits: &ValidationLimits) -> Result<(), Va
             server_capabilities,
             ..
         } => validate_capabilities(server_capabilities, limits),
-        Frame::RegisterAck { public_url, .. } => {
-            check_field_len(public_url.len(), limits.max_url_len)
-        }
-        Frame::Data { data, .. } => validate_payload(data.len(), limits),
         Frame::Register {
             service_name,
             metadata,
             ..
         } => validate_register(service_name, metadata, limits),
+        Frame::RegisterAck { public_url, .. } => {
+            check_field_len(public_url.len(), limits.max_url_len)
+        }
         Frame::OpenStream(open) => validate_open_stream(open, limits),
+        Frame::Data { data, .. } => validate_payload(data.len(), limits),
+        Frame::CloseStream { reason, .. } => validate_close_reason(reason, limits),
         Frame::Error { message, .. } => {
             check_field_len(message.len(), limits.max_error_message_len)
         }
-        Frame::CloseStream {
-            reason: CloseReason::Error(message),
-            ..
-        } => check_field_len(message.len(), limits.max_error_message_len),
         Frame::PluginData { plugin_id, data } => {
             check_field_len(plugin_id.len(), limits.max_name_len)?;
             validate_payload(data.len(), limits)
         }
-        _ => Ok(()),
+        Frame::StreamAck { .. } | Frame::Heartbeat { .. } | Frame::HeartbeatAck { .. } => Ok(()),
     }
 }
 

--- a/ferrotunnel/Cargo.toml
+++ b/ferrotunnel/Cargo.toml
@@ -12,11 +12,11 @@ keywords = ["tunnel", "reverse-proxy", "networking", "async"]
 categories = ["network-programming", "asynchronous"]
 
 [dependencies]
-ferrotunnel-common = { version = "1.3.0", path = "../ferrotunnel-common" }
-ferrotunnel-protocol = { version = "1.3.0", path = "../ferrotunnel-protocol" }
-ferrotunnel-core = { version = "1.3.0", path = "../ferrotunnel-core" }
-ferrotunnel-http = { version = "1.3.0", path = "../ferrotunnel-http" }
-ferrotunnel-plugin = { version = "1.3.0", path = "../ferrotunnel-plugin" }
+ferrotunnel-common = { version = "1.4.0", path = "../ferrotunnel-common" }
+ferrotunnel-protocol = { version = "1.4.0", path = "../ferrotunnel-protocol" }
+ferrotunnel-core = { version = "1.4.0", path = "../ferrotunnel-core" }
+ferrotunnel-http = { version = "1.4.0", path = "../ferrotunnel-http" }
+ferrotunnel-plugin = { version = "1.4.0", path = "../ferrotunnel-plugin" }
 
 # Re-export commonly used dependencies
 tokio = { workspace = true }

--- a/ferrotunnel/src/client.rs
+++ b/ferrotunnel/src/client.rs
@@ -355,7 +355,10 @@ impl ClientBuilder {
         self
     }
 
-    /// Configure resource limits.
+    /// Configure resource limits (frame size, session, and stream bounds).
+    ///
+    /// Defaults to [`LimitsConfig::default`]. A `max_frame_bytes` of `0` or a
+    /// value larger than `u32::MAX` is rejected by [`ClientBuilder::build`].
     #[must_use]
     pub fn limits(mut self, limits: &LimitsConfig) -> Self {
         self.config.limits = limits.clone();

--- a/ferrotunnel/src/client.rs
+++ b/ferrotunnel/src/client.rs
@@ -19,7 +19,7 @@
 //! ```
 
 use crate::config::{ClientConfig, TunnelInfo};
-use ferrotunnel_common::config::TlsConfig;
+use ferrotunnel_common::config::{LimitsConfig, TlsConfig};
 use ferrotunnel_common::{Result, TunnelError};
 use ferrotunnel_core::transport::{tls::TlsTransportConfig, TransportConfig};
 use ferrotunnel_core::TunnelClient;
@@ -100,6 +100,7 @@ impl Client {
         let auto_reconnect = config.auto_reconnect;
         let reconnect_delay = config.reconnect_delay;
         let startup_timeout = config.startup_timeout;
+        let limits = config.limits.clone();
         let transport_config = self.transport_config.clone();
 
         let info_tx = Arc::new(Mutex::new(Some(info_tx)));
@@ -117,7 +118,8 @@ impl Client {
 
             loop {
                 let mut client = TunnelClient::new(server_addr.clone(), token.clone())
-                    .with_transport(transport_config.clone());
+                    .with_transport(transport_config.clone())
+                    .with_limits(limits.clone());
                 if let Some(ref id) = tunnel_id {
                     client = client.with_tunnel_id(id.clone());
                 }
@@ -353,6 +355,13 @@ impl ClientBuilder {
         self
     }
 
+    /// Configure resource limits.
+    #[must_use]
+    pub fn limits(mut self, limits: &LimitsConfig) -> Self {
+        self.config.limits = limits.clone();
+        self
+    }
+
     /// Configure TLS for the connection.
     ///
     /// When enabled, the client will use TLS to connect to the server.
@@ -420,6 +429,10 @@ mod tests {
             .local_addr("127.0.0.1:3000")
             .auto_reconnect(false)
             .reconnect_delay(Duration::from_secs(10))
+            .limits(&LimitsConfig {
+                max_frame_bytes: 4096,
+                ..Default::default()
+            })
             .build()
             .expect("should build successfully");
 
@@ -428,6 +441,7 @@ mod tests {
         assert_eq!(client.config().local_addr, "127.0.0.1:3000");
         assert!(!client.config().auto_reconnect);
         assert_eq!(client.config().reconnect_delay, Duration::from_secs(10));
+        assert_eq!(client.config().limits.max_frame_bytes, 4096);
     }
 
     #[test]

--- a/ferrotunnel/src/config.rs
+++ b/ferrotunnel/src/config.rs
@@ -4,7 +4,7 @@
 //! in your applications.
 
 use ferrotunnel_common::{
-    Result, TunnelError, DEFAULT_HTTP_PORT, DEFAULT_LOCAL_ADDR, DEFAULT_TUNNEL_PORT,
+    LimitsConfig, Result, TunnelError, DEFAULT_HTTP_PORT, DEFAULT_LOCAL_ADDR, DEFAULT_TUNNEL_PORT,
 };
 use std::net::SocketAddr;
 #[cfg(feature = "http3")]
@@ -36,6 +36,9 @@ pub struct ClientConfig {
 
     /// Maximum time to wait for the initial connection in `start()`. `None` waits indefinitely. Default 30s.
     pub startup_timeout: Option<Duration>,
+
+    /// Resource limits for protocol framing and connection handling.
+    pub limits: LimitsConfig,
 }
 
 impl ClientConfig {
@@ -50,6 +53,7 @@ impl ClientConfig {
         if self.local_addr.is_empty() {
             return Err(TunnelError::Config("local_addr is required".into()));
         }
+        validate_limits(&self.limits)?;
         Ok(())
     }
 }
@@ -64,6 +68,7 @@ impl Default for ClientConfig {
             auto_reconnect: true,
             reconnect_delay: Duration::from_secs(5),
             startup_timeout: Some(Duration::from_secs(30)),
+            limits: LimitsConfig::default(),
         }
     }
 }
@@ -93,6 +98,9 @@ pub struct ServerConfig {
 
     /// Authentication token (clients must provide this)
     pub token: String,
+
+    /// Resource limits for protocol framing and connection handling.
+    pub limits: LimitsConfig,
 }
 
 impl ServerConfig {
@@ -101,6 +109,7 @@ impl ServerConfig {
         if self.token.is_empty() {
             return Err(TunnelError::Config("token is required".into()));
         }
+        validate_limits(&self.limits)?;
         #[cfg(feature = "http3")]
         if self.http3_bind_addr.is_some()
             && (self.http3_cert_path.is_none() || self.http3_key_path.is_none())
@@ -125,8 +134,23 @@ impl Default for ServerConfig {
             #[cfg(feature = "http3")]
             http3_key_path: None,
             token: String::new(),
+            limits: LimitsConfig::default(),
         }
     }
+}
+
+fn validate_limits(limits: &LimitsConfig) -> Result<()> {
+    if limits.max_frame_bytes == 0 {
+        return Err(TunnelError::Config(
+            "limits.max_frame_bytes must be greater than zero".into(),
+        ));
+    }
+    if limits.max_frame_bytes > u64::from(u32::MAX) {
+        return Err(TunnelError::Config(
+            "limits.max_frame_bytes must fit in the wire length prefix".into(),
+        ));
+    }
+    Ok(())
 }
 
 /// Information about an established tunnel connection.
@@ -155,6 +179,7 @@ mod tests {
         assert!(config.auto_reconnect);
         assert_eq!(config.reconnect_delay, Duration::from_secs(5));
         assert_eq!(config.startup_timeout, Some(Duration::from_secs(30)));
+        assert_eq!(config.limits.max_frame_bytes, 16 * 1024 * 1024);
     }
 
     #[test]
@@ -166,6 +191,32 @@ mod tests {
             ..Default::default()
         };
         assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_client_config_validate_rejects_zero_frame_limit() {
+        let mut config = ClientConfig {
+            server_addr: "localhost:7835".to_string(),
+            token: "secret-token".to_string(),
+            local_addr: "127.0.0.1:8080".to_string(),
+            ..Default::default()
+        };
+        config.limits.max_frame_bytes = 0;
+        let err = config.validate().unwrap_err();
+        assert!(err.to_string().contains("max_frame_bytes"));
+    }
+
+    #[test]
+    fn test_client_config_validate_rejects_oversized_frame_limit() {
+        let mut config = ClientConfig {
+            server_addr: "localhost:7835".to_string(),
+            token: "secret-token".to_string(),
+            local_addr: "127.0.0.1:8080".to_string(),
+            ..Default::default()
+        };
+        config.limits.max_frame_bytes = u64::from(u32::MAX) + 1;
+        let err = config.validate().unwrap_err();
+        assert!(err.to_string().contains("wire length prefix"));
     }
 
     #[test]
@@ -213,6 +264,7 @@ mod tests {
             SocketAddr::from(([0, 0, 0, 0], 8080))
         );
         assert!(config.token.is_empty());
+        assert_eq!(config.limits.max_frame_bytes, 16 * 1024 * 1024);
     }
 
     #[test]
@@ -222,6 +274,28 @@ mod tests {
             ..Default::default()
         };
         assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_server_config_validate_rejects_zero_frame_limit() {
+        let mut config = ServerConfig {
+            token: "secret-token".to_string(),
+            ..Default::default()
+        };
+        config.limits.max_frame_bytes = 0;
+        let err = config.validate().unwrap_err();
+        assert!(err.to_string().contains("max_frame_bytes"));
+    }
+
+    #[test]
+    fn test_server_config_validate_rejects_oversized_frame_limit() {
+        let mut config = ServerConfig {
+            token: "secret-token".to_string(),
+            ..Default::default()
+        };
+        config.limits.max_frame_bytes = u64::from(u32::MAX) + 1;
+        let err = config.validate().unwrap_err();
+        assert!(err.to_string().contains("wire length prefix"));
     }
 
     #[test]

--- a/ferrotunnel/src/config.rs
+++ b/ferrotunnel/src/config.rs
@@ -6,6 +6,7 @@
 use ferrotunnel_common::{
     LimitsConfig, Result, TunnelError, DEFAULT_HTTP_PORT, DEFAULT_LOCAL_ADDR, DEFAULT_TUNNEL_PORT,
 };
+use ferrotunnel_core::validate_limits;
 use std::net::SocketAddr;
 #[cfg(feature = "http3")]
 use std::path::PathBuf;
@@ -139,20 +140,6 @@ impl Default for ServerConfig {
     }
 }
 
-fn validate_limits(limits: &LimitsConfig) -> Result<()> {
-    if limits.max_frame_bytes == 0 {
-        return Err(TunnelError::Config(
-            "limits.max_frame_bytes must be greater than zero".into(),
-        ));
-    }
-    if limits.max_frame_bytes > u64::from(u32::MAX) {
-        return Err(TunnelError::Config(
-            "limits.max_frame_bytes must fit in the wire length prefix".into(),
-        ));
-    }
-    Ok(())
-}
-
 /// Information about an established tunnel connection.
 #[derive(Debug, Clone)]
 pub struct TunnelInfo {
@@ -214,9 +201,10 @@ mod tests {
             local_addr: "127.0.0.1:8080".to_string(),
             ..Default::default()
         };
-        config.limits.max_frame_bytes = u64::from(u32::MAX) + 1;
+        // Just above the protocol frame ceiling (16 MiB) is now rejected.
+        config.limits.max_frame_bytes = 17 * 1024 * 1024;
         let err = config.validate().unwrap_err();
-        assert!(err.to_string().contains("wire length prefix"));
+        assert!(err.to_string().contains("max_frame_bytes"));
     }
 
     #[test]
@@ -293,9 +281,10 @@ mod tests {
             token: "secret-token".to_string(),
             ..Default::default()
         };
-        config.limits.max_frame_bytes = u64::from(u32::MAX) + 1;
+        // Just above the protocol frame ceiling (16 MiB) is now rejected.
+        config.limits.max_frame_bytes = 17 * 1024 * 1024;
         let err = config.validate().unwrap_err();
-        assert!(err.to_string().contains("wire length prefix"));
+        assert!(err.to_string().contains("max_frame_bytes"));
     }
 
     #[test]

--- a/ferrotunnel/src/server.rs
+++ b/ferrotunnel/src/server.rs
@@ -20,8 +20,9 @@
 //! ```
 
 use crate::config::ServerConfig;
-use ferrotunnel_common::config::TlsConfig;
+use ferrotunnel_common::config::{LimitsConfig, TlsConfig};
 use ferrotunnel_common::{Result, TunnelError};
+use ferrotunnel_core::resource_limits::ServerResourceLimits;
 use ferrotunnel_core::transport::{tls::TlsTransportConfig, TransportConfig};
 use ferrotunnel_core::TunnelServer;
 use ferrotunnel_http::HttpIngress;
@@ -117,8 +118,16 @@ impl Server {
 
         #[cfg(feature = "quic")]
         let tunnel_transport = transport_config.clone();
-        let tunnel_server =
-            TunnelServer::new(config.bind_addr, config.token).with_transport(transport_config);
+        let tunnel_limits = config.limits.clone();
+        let resource_limits = ServerResourceLimits::new(
+            tunnel_limits.max_sessions,
+            tunnel_limits.max_streams_per_session,
+            tunnel_limits.max_inflight_frames,
+        );
+        let tunnel_server = TunnelServer::new(config.bind_addr, config.token)
+            .with_transport(transport_config)
+            .with_limits(tunnel_limits)
+            .with_resource_limits(resource_limits);
 
         // Initialize plugins
         let mut registry = PluginRegistry::new();
@@ -354,6 +363,13 @@ impl ServerBuilder {
         self
     }
 
+    /// Configure resource limits.
+    #[must_use]
+    pub fn limits(mut self, limits: &LimitsConfig) -> Self {
+        self.config.limits = limits.clone();
+        self
+    }
+
     /// Configure QUIC transport for the server.
     ///
     /// When enabled, the server will accept QUIC connections for the tunnel control plane.
@@ -406,6 +422,10 @@ mod tests {
             .bind("0.0.0.0:9000".parse().unwrap())
             .http_bind("0.0.0.0:9001".parse().unwrap())
             .token("my-token")
+            .limits(&LimitsConfig {
+                max_frame_bytes: 4096,
+                ..Default::default()
+            })
             .build()
             .expect("should build successfully");
 
@@ -415,6 +435,7 @@ mod tests {
             "0.0.0.0:9001".parse().unwrap()
         );
         assert_eq!(server.config().token, "my-token");
+        assert_eq!(server.config().limits.max_frame_bytes, 4096);
     }
 
     #[test]

--- a/ferrotunnel/src/server.rs
+++ b/ferrotunnel/src/server.rs
@@ -363,7 +363,10 @@ impl ServerBuilder {
         self
     }
 
-    /// Configure resource limits.
+    /// Configure resource limits (frame size, session, and stream bounds).
+    ///
+    /// Defaults to [`LimitsConfig::default`]. A `max_frame_bytes` of `0` or a
+    /// value larger than `u32::MAX` is rejected by [`ServerBuilder::build`].
     #[must_use]
     pub fn limits(mut self, limits: &LimitsConfig) -> Self {
         self.config.limits = limits.clone();

--- a/tests/integration/http3_test.rs
+++ b/tests/integration/http3_test.rs
@@ -62,10 +62,6 @@ fn http3_context() -> Http3TestContext {
 
 #[tokio::test]
 async fn test_http3_request_through_tunnel_and_alt_svc_advertised() {
-    let _ = rustls::crypto::ring::default_provider()
-        .install_default()
-        .ok();
-
     let context = http3_context();
     let local_port = get_free_port();
     let local_addr = format!("127.0.0.1:{local_port}");
@@ -134,10 +130,6 @@ async fn test_http3_request_through_tunnel_and_alt_svc_advertised() {
 
 #[tokio::test]
 async fn test_http3_unknown_host_returns_not_found() {
-    let _ = rustls::crypto::ring::default_provider()
-        .install_default()
-        .ok();
-
     let context = http3_context();
     let mut server = Server::builder()
         .bind(context.server_addr)

--- a/tests/integration/quic_test.rs
+++ b/tests/integration/quic_test.rs
@@ -44,10 +44,6 @@ async fn wait_for_quic_server(
 /// Test basic QUIC connection: client connects to server, handshake succeeds
 #[tokio::test]
 async fn test_quic_connection() {
-    let _ = rustls::crypto::ring::default_provider()
-        .install_default()
-        .ok();
-
     let quic_port = get_free_port();
     let local_port = get_free_port();
     let quic_addr: std::net::SocketAddr = format!("127.0.0.1:{quic_port}").parse().unwrap();
@@ -169,10 +165,6 @@ async fn test_quic_connection() {
 /// Test the public builder APIs over QUIC with HTTP ingress routing.
 #[tokio::test]
 async fn test_public_api_quic_routing() {
-    let _ = rustls::crypto::ring::default_provider()
-        .install_default()
-        .ok();
-
     let quic_port = get_free_port();
     let http_port = get_free_port();
     let local_port = get_free_port();

--- a/tests/integration/tls_test.rs
+++ b/tests/integration/tls_test.rs
@@ -9,9 +9,6 @@ use std::time::Duration;
 /// Test client connecting to server over TLS
 #[tokio::test]
 async fn test_tls_connection() {
-    let _ = rustls::crypto::ring::default_provider()
-        .install_default()
-        .ok();
     let config = TestConfig::default();
 
     // Create temp directory for certs

--- a/tools/soak/Cargo.toml
+++ b/tools/soak/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 publish = false
 
 [dependencies]
-ferrotunnel = { version = "1.3.0", path = "../../ferrotunnel" }
+ferrotunnel = { version = "1.4.0", path = "../../ferrotunnel" }
 tokio = { workspace = true }
 clap = { version = "4", features = ["derive"] }
 anyhow = { workspace = true }


### PR DESCRIPTION
Protocol and configuration hardening release closing the v1.4.0 milestone.

## Security

- **#139** — Validate every wire-frame variant in the decode path. All
  variable-length control-frame contents (metadata, headers, service names,
  URLs, error/close messages, plugin ids) are now bounded on cardinality and
  per-element size, and validation runs inside `TunnelCodec::decode` for both
  peers.
- **#163** — Bound the control-frame decode allocation to the frame size. The
  bincode decode budget is capped at the physical frame length (plus a small
  collection-backbone headroom), so a small frame can no longer force a large
  allocation while decoding.

## Fixed

- **#144** — Wire the configured frame/limit settings through to the codec so
  `max_frame_bytes` is enforced by client and server; reject a zero or oversized
  configured limit at the configuration boundary.
- **#121** — Install the rustls crypto provider automatically for embedded
  library TLS users, so `Client`/`Server` builders no longer require a manual
  provider install.

## Docs

- Add a public-facing wording policy to `AGENTS.md`.
- `CHANGELOG.md` and `ROADMAP.md` updated for 1.4.0; workspace version bumped
  1.3.0 → 1.4.0.

## Test plan

- [x] `make check` (rustfmt + clippy pedantic, `-D warnings`)
- [x] `cargo test --workspace --all-features`
- [x] `cargo +nightly fuzz build` (protocol targets)
- [x] `make audit` (cargo-audit + cargo-deny) — clean
- [x] New decode-path regression tests for oversized `Register`/`OpenStream`/
  `CloseStream` and for the allocation bound

Closes #139
Closes #144
Closes #121
Closes #163


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable protocol/frame and resource limits for both client and server, including new builder options to set `LimitsConfig`.
* **Bug Fixes**
  * Hardened wire-protocol decoding/validation by rejecting oversized or abusive control-frame and variable-length contents, with bounded allocations and clearer invalid-data errors.
  * TLS now automatically installs the default crypto provider during config construction.
* **Tests**
  * Expanded limit/validation test coverage and updated integration tests to rely on on-demand TLS crypto initialization.
* **Documentation**
  * Added the v1.4.0 changelog entry and guidance for public-facing repository wording.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->