### PR TITLE
Release 1.5.0 — public-API encapsulation & audit hardening

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,7 +69,7 @@ Internet → HttpIngress(:8080) → SessionStore → AnyMultiplexer → [TCP: Mu
 - **`unsafe_code = "forbid"`** at workspace level — no unsafe code
 - **Clippy pedantic** enabled; `unwrap_used` and `expect_used` warn (allowed in tests)
 - `dbg!`, `todo!`, `unimplemented!` are warnings
-- Edition 2021, MSRV 1.90, max line width 100, 4-space indent
+- Edition 2021, MSRV 1.91, max line width 100, 4-space indent
 - Use `thiserror` for library errors, `anyhow` for CLI/application errors
 - Prefer `Bytes` for zero-copy buffers, `kanal` for async channels, `DashMap` for concurrent maps
 - TLS uses `rustls` 0.23 + ring crypto provider (must call `install_default()` before any TLS config)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,62 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.0] - 2026-07-04
+
+Public-API and audit hardening release closing the v1.5.0 milestone and part of
+the v1.5.x audit backlog.
+
+### ⚠ Breaking changes
+
+- Configuration types are now encapsulated. `ClientConfig`, `ServerConfig`, and
+  `TunnelInfo` fields are private with public getters: construct them through
+  `Client::builder()` / `Server::builder()` and read them back with the
+  accessors (for example `config.token()`, `info.session_id()`) instead of
+  field access. This prevents mutation after `build()` and keeps the
+  authentication token out of `Debug` output ([#140](https://github.com/ferro-labs/ferrotunnel/issues/140)).
+
+### Security
+
+- Redact the authentication token in the `Debug` output of `ClientConfig` and
+  `ServerConfig` ([#140](https://github.com/ferro-labs/ferrotunnel/issues/140)).
+- Return a generic 401 reason from the token-auth plugin so a missing token and
+  a wrong token are indistinguishable and the expected header name is not
+  disclosed ([#145](https://github.com/ferro-labs/ferrotunnel/issues/145)).
+
+### Fixed
+
+- Make builder TLS configuration fail at `build()` time: a disabled config or
+  empty/incomplete certificate, key, or CA paths are now rejected instead of
+  silently leaving the transport unchanged ([#141](https://github.com/ferro-labs/ferrotunnel/issues/141)).
+- Propagate the CLI `--tls-client-auth`/`--tls-ca` validation error through
+  `main` instead of calling `std::process::exit`, so tracing and shutdown run
+  ([#142](https://github.com/ferro-labs/ferrotunnel/issues/142)).
+- Honor response-plugin `Reject`/`Respond` decisions on the HTTP/1 ingress path,
+  which previously discarded them ([#145](https://github.com/ferro-labs/ferrotunnel/issues/145)).
+- Strip hop-by-hop headers on the HTTP/1 forward path, matching the HTTP/3 path,
+  while preserving them for WebSocket upgrades ([#145](https://github.com/ferro-labs/ferrotunnel/issues/145)).
+- Propagate HTTP/3 request-body read errors instead of converting them to a
+  clean EOF that silently truncates the upstream body ([#145](https://github.com/ferro-labs/ferrotunnel/issues/145)).
+- Fail stream-ID allocation when the ID space is exhausted instead of wrapping
+  and aliasing a live stream ([#145](https://github.com/ferro-labs/ferrotunnel/issues/145)).
+- Capture the full request path and query for request replay so a replayed
+  request matches the original ([#145](https://github.com/ferro-labs/ferrotunnel/issues/145)).
+- Report tracing/OTLP initialization failures instead of discarding them
+  ([#145](https://github.com/ferro-labs/ferrotunnel/issues/145)).
+- Enforce the `HandshakeFrame` `min_version <= max_version` invariant during
+  frame validation ([#145](https://github.com/ferro-labs/ferrotunnel/issues/145)).
+
+### Changed
+
+- Hide the `core`, `http`, and `protocol` implementation-crate re-exports from
+  the public API documentation ([#140](https://github.com/ferro-labs/ferrotunnel/issues/140)).
+- Unify the duplicate `rand` dependency on 0.9 and document the `cargo-deny`
+  duplicate-version policy ([#122](https://github.com/ferro-labs/ferrotunnel/issues/122)).
+- Align the advertised MSRV (README, CONTRIBUTING, CLI, Dockerfile) with the
+  1.91 toolchain used by the manifest and CI ([#123](https://github.com/ferro-labs/ferrotunnel/issues/123)).
+- Mark `Client::builder()` / `Server::builder()` `#[must_use]` and document the
+  `burst_factor` bound ([#145](https://github.com/ferro-labs/ferrotunnel/issues/145)).
+
 ## [1.4.0] - 2026-07-03
 
 Protocol and configuration hardening release closing the v1.4.0 milestone.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ All contributors are expected to follow our [Code of Conduct](CODE_OF_CONDUCT.md
 ## Development Setup
 
 ### Prerequisites
-- [Rust](https://www.rust-lang.org/tools/install) (stable, version 1.90+)
+- [Rust](https://www.rust-lang.org/tools/install) (stable, version 1.91+)
 - `make` (for running development commands)
 
 ### Common Commands

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.4.0"
+version = "1.5.0"
 edition = "2021"
 rust-version = "1.91"
 authors = ["Mitul Shah <hello@ferrolabs.ai>"]
@@ -53,7 +53,7 @@ tokio = { version = "1", features = ["full"] }
 
 # Logging
 tracing = "0.1"
-ferrotunnel-observability = { version = "1.4.0", path = "ferrotunnel-observability" }
+ferrotunnel-observability = { version = "1.5.0", path = "ferrotunnel-observability" }
 
 # QUIC transport
 quinn = { version = "0.11", default-features = false, features = ["runtime-tokio", "rustls-ring"] }

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Crates.io](https://img.shields.io/crates/v/ferrotunnel)](https://crates.io/crates/ferrotunnel)
 [![Documentation](https://docs.rs/ferrotunnel/badge.svg)](https://docs.rs/ferrotunnel)
 [![License](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](LICENSE)
-[![Rust Version](https://img.shields.io/badge/rust-1.90%2B-orange.svg)](https://www.rust-lang.org)
+[![Rust Version](https://img.shields.io/badge/rust-1.91%2B-orange.svg)](https://www.rust-lang.org)
 [![Discord](https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white)](https://discord.gg/yCAeYvJeDV)
 
 **High-performance reverse tunnel you can embed in your Rust applications.**
@@ -14,7 +14,7 @@ FerroTunnel multiplexes streams over a single connection (like ngrok/Cloudflare 
 
 ## Prerequisites
 
-- **Rust 1.90+**: FerroTunnel uses modern Rust features for performance and safety.
+- **Rust 1.91+**: FerroTunnel uses modern Rust features for performance and safety.
 - **Cargo**: Required for building and installing from source.
 - **Git**: For cloning the repository during development.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -53,10 +53,11 @@ Embeddable, extensible, and observable reverse tunnel for Rust developers.
   - CLI flags: `--quic-bind` (server), `--quic` / `--quic-0rtt` (client)
   - **Differentiator**: Next-gen transport for competitive advantage
 
-- **v1.1.0 – v1.4.0** - Security & Reliability Hardening ✅
+- **v1.1.0 – v1.5.0** - Security & Reliability Hardening ✅
   - Audit-driven hardening across dashboard/TLS auth (v1.1.0), ingress and
     session-resource limits (v1.2.0), concurrency and lifecycle correctness
-    (v1.3.0), and wire-protocol and configuration hardening (v1.4.0)
+    (v1.3.0), wire-protocol and configuration hardening (v1.4.0), and public-API
+    encapsulation with authentication-token redaction (v1.5.0)
   - **Value**: Production-grade robustness ahead of the API-stabilization window
 
 ### Planned

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -50,7 +50,6 @@ tokio = { workspace = true }
 tokio-util = { workspace = true }
 criterion = { version = "0.8", features = ["async_tokio"] }
 bytes = { workspace = true }
-rand = "0.8"
 bincode-next = { workspace = true }
 http = "1.0"
 kanal = "0.1"

--- a/deny.toml
+++ b/deny.toml
@@ -154,7 +154,15 @@ registries = [
 # More documentation about the 'bans' section can be found here:
 # https://embarkstudios.github.io/cargo-deny/checks/bans/cfg.html
 [bans]
-# Lint level for when multiple versions of the same crate are detected
+# Lint level for when multiple versions of the same crate are detected.
+# Kept at "warn" rather than "deny" on purpose: the remaining duplicates are
+# transitive (e.g. thiserror 1.x pulled by upstream crates, and the
+# windows-sys/windows-targets family required by the async runtime and TLS
+# stack) and are outside our direct control. Failing the build on them would
+# block releases for reasons we cannot fix. They stay visible as warnings so
+# newly introduced, avoidable duplicates remain easy to spot. Avoidable
+# duplicates from our own direct dependencies are unified in the manifests
+# instead (e.g. rand is pinned to 0.9 to match governor's transitive rand).
 multiple-versions = "warn"
 # Lint level for when a crate version requirement is `*`
 wildcards = "allow"

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -197,7 +197,7 @@ sudo systemctl start ferrotunnel
 
 ```dockerfile
 # Dockerfile
-FROM rust:1.90-slim as builder
+FROM rust:1.91-slim as builder
 WORKDIR /app
 COPY . .
 RUN cargo build --release -p ferrotunnel-cli

--- a/ferrotunnel-cli/Cargo.toml
+++ b/ferrotunnel-cli/Cargo.toml
@@ -17,12 +17,12 @@ doc = false
 
 [dependencies]
 # Core functionality
-ferrotunnel-core = { version = "1.4.0", path = "../ferrotunnel-core", features = [
+ferrotunnel-core = { version = "1.5.0", path = "../ferrotunnel-core", features = [
     "metrics",
 ] }
-ferrotunnel-http = { version = "1.4.0", path = "../ferrotunnel-http" }
-ferrotunnel-protocol = { version = "1.4.0", path = "../ferrotunnel-protocol" }
-ferrotunnel-plugin = { version = "1.4.0", path = "../ferrotunnel-plugin" }
+ferrotunnel-http = { version = "1.5.0", path = "../ferrotunnel-http" }
+ferrotunnel-protocol = { version = "1.5.0", path = "../ferrotunnel-protocol" }
+ferrotunnel-plugin = { version = "1.5.0", path = "../ferrotunnel-plugin" }
 ferrotunnel-observability = { workspace = true, features = [
     "dashboard",
     "axum",

--- a/ferrotunnel-cli/src/commands/server.rs
+++ b/ferrotunnel-cli/src/commands/server.rs
@@ -1,6 +1,6 @@
 //! Server subcommand implementation
 
-use anyhow::{Context, Result};
+use anyhow::{anyhow, Context, Result};
 use clap::Args;
 use ferrotunnel_core::TunnelServer;
 use ferrotunnel_observability::{
@@ -121,6 +121,8 @@ fn prompt_token() -> Result<String> {
 
 #[allow(clippy::too_many_lines)]
 pub async fn run(args: ServerArgs) -> Result<()> {
+    validate_args(&args)?;
+
     let enable_tracing = args.observability;
     let enable_metrics = args.metrics;
 
@@ -189,9 +191,6 @@ pub async fn run(args: ServerArgs) -> Result<()> {
         if let Some(ca_path) = &args.tls_ca {
             info!("TLS Client Authentication enabled with CA: {:?}", ca_path);
             server = server.with_client_auth(ca_path.clone());
-        } else if args.tls_client_auth {
-            error!("--tls-client-auth requires --tls-ca to be provided");
-            std::process::exit(1);
         }
     }
     let sessions = server.sessions();
@@ -356,10 +355,49 @@ pub async fn run(args: ServerArgs) -> Result<()> {
     Ok(())
 }
 
+fn validate_args(args: &ServerArgs) -> Result<()> {
+    if args.tls_client_auth && args.tls_ca.is_none() {
+        return Err(anyhow!(
+            "--tls-client-auth requires --tls-ca to be provided"
+        ));
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn server_args() -> ServerArgs {
+        ServerArgs {
+            bind: SocketAddr::from(([127, 0, 0, 1], 7835)),
+            token_file: None,
+            log_level: "info".to_string(),
+            http_bind: SocketAddr::from(([127, 0, 0, 1], 8080)),
+            metrics_bind: SocketAddr::from(([127, 0, 0, 1], 9090)),
+            tls_cert: None,
+            tls_key: None,
+            tls_ca: None,
+            tls_client_auth: false,
+            tcp_bind: None,
+            #[cfg(feature = "http3")]
+            http3_bind: None,
+            #[cfg(feature = "http3")]
+            http3_cert: None,
+            #[cfg(feature = "http3")]
+            http3_key: None,
+            observability: false,
+            metrics: false,
+            #[cfg(feature = "quic")]
+            quic_bind: None,
+            #[cfg(feature = "quic")]
+            quic_cert: None,
+            #[cfg(feature = "quic")]
+            quic_key: None,
+        }
+    }
 
     #[test]
     fn read_token_file_trims_trailing_line_endings() {
@@ -376,5 +414,31 @@ mod tests {
         let _ = std::fs::remove_file(&path);
 
         assert_eq!(token, "secret");
+    }
+
+    #[test]
+    fn tls_client_auth_requires_ca() {
+        let args = ServerArgs {
+            tls_client_auth: true,
+            ..server_args()
+        };
+
+        let error = validate_args(&args).err().map(|err| err.to_string());
+
+        assert_eq!(
+            error.as_deref(),
+            Some("--tls-client-auth requires --tls-ca to be provided")
+        );
+    }
+
+    #[test]
+    fn tls_client_auth_accepts_ca() {
+        let args = ServerArgs {
+            tls_client_auth: true,
+            tls_ca: Some(PathBuf::from("ca.pem")),
+            ..server_args()
+        };
+
+        assert!(validate_args(&args).is_ok());
     }
 }

--- a/ferrotunnel-cli/src/commands/version.rs
+++ b/ferrotunnel-cli/src/commands/version.rs
@@ -16,5 +16,5 @@ pub fn run() {
 
 fn rustc_version() -> &'static str {
     // This would ideally come from build.rs, but for simplicity we use a placeholder
-    "1.90+"
+    "1.91+"
 }

--- a/ferrotunnel-cli/src/middleware.rs
+++ b/ferrotunnel-cli/src/middleware.rs
@@ -88,7 +88,12 @@ where
             }
 
             let request_method = parts.method.to_string();
-            let request_path = parts.uri.path().to_string();
+            // Capture the full path and query so a replayed request matches the
+            // original; `uri.path()` alone would drop the query string.
+            let request_path = parts
+                .uri
+                .path_and_query()
+                .map_or_else(|| parts.uri.path().to_string(), |pq| pq.as_str().to_string());
 
             let request_bytes = match body.collect().await {
                 Ok(c) => c.to_bytes(),

--- a/ferrotunnel-cli/src/middleware.rs
+++ b/ferrotunnel-cli/src/middleware.rs
@@ -90,10 +90,10 @@ where
             let request_method = parts.method.to_string();
             // Capture the full path and query so a replayed request matches the
             // original; `uri.path()` alone would drop the query string.
-            let request_path = parts
-                .uri
-                .path_and_query()
-                .map_or_else(|| parts.uri.path().to_string(), |pq| pq.as_str().to_string());
+            let request_path = parts.uri.path_and_query().map_or_else(
+                || parts.uri.path().to_string(),
+                |pq| pq.as_str().to_string(),
+            );
 
             let request_bytes = match body.collect().await {
                 Ok(c) => c.to_bytes(),

--- a/ferrotunnel-common/src/config.rs
+++ b/ferrotunnel-common/src/config.rs
@@ -70,7 +70,11 @@ pub struct RateLimitConfig {
     pub streams_per_sec: u32,
     /// Maximum bytes per second per session
     pub bytes_per_sec: u64,
-    /// Burst allowance multiplier
+    /// Burst allowance multiplier applied to the per-second rates.
+    ///
+    /// The effective burst capacity is `rate * burst_factor`, saturating at
+    /// `u32::MAX`; a value of `0` is treated as `1` by the rate limiter. Values
+    /// beyond a small single-digit multiple offer no practical benefit.
     pub burst_factor: u32,
 }
 

--- a/ferrotunnel-core/Cargo.toml
+++ b/ferrotunnel-core/Cargo.toml
@@ -39,7 +39,7 @@ sha2 = "0.10"
 # Rate limiting
 governor = "0.10"
 nonzero_ext = "0.3"
-rand = "0.8"
+rand = "0.9"
 
 # Socket tuning for performance
 socket2 = "0.6"

--- a/ferrotunnel-core/Cargo.toml
+++ b/ferrotunnel-core/Cargo.toml
@@ -12,8 +12,8 @@ keywords = ["tunnel", "networking", "async", "core"]
 categories = ["network-programming", "asynchronous"]
 
 [dependencies]
-ferrotunnel-common = { version = "1.4.0", path = "../ferrotunnel-common" }
-ferrotunnel-protocol = { version = "1.4.0", path = "../ferrotunnel-protocol" }
+ferrotunnel-common = { version = "1.5.0", path = "../ferrotunnel-common" }
+ferrotunnel-protocol = { version = "1.5.0", path = "../ferrotunnel-protocol" }
 
 tokio = { workspace = true }
 tokio-util = { workspace = true }
@@ -54,7 +54,7 @@ crossbeam-queue = "0.3"
 quinn = { workspace = true, optional = true }
 
 # Optional metrics (decode/encode latency, queue depth)
-ferrotunnel-observability = { version = "1.4.0", path = "../ferrotunnel-observability", optional = true }
+ferrotunnel-observability = { version = "1.5.0", path = "../ferrotunnel-observability", optional = true }
 
 # File descriptor exhaustion (EMFILE/ENFILE) detection in accept-loop backoff
 [target.'cfg(unix)'.dependencies]

--- a/ferrotunnel-core/src/reconnect.rs
+++ b/ferrotunnel-core/src/reconnect.rs
@@ -78,7 +78,7 @@ impl Backoff {
 
         // Apply jitter
         let jitter_range = exp_delay * self.config.jitter;
-        let jitter = rand::thread_rng().gen_range(-jitter_range..=jitter_range);
+        let jitter = rand::rng().random_range(-jitter_range..=jitter_range);
         let delay_with_jitter = (exp_delay + jitter).max(0.0);
 
         // Clamp to max

--- a/ferrotunnel-core/src/stream/multiplexer.rs
+++ b/ferrotunnel-core/src/stream/multiplexer.rs
@@ -10,7 +10,7 @@ use super::pool::ObjectPool;
 use bytes::Bytes;
 use dashmap::mapref::entry::Entry;
 use dashmap::DashMap;
-use ferrotunnel_common::Result;
+use ferrotunnel_common::{Result, TunnelError};
 use ferrotunnel_protocol::frame::{Frame, OpenStreamFrame, Protocol, StreamPriority};
 use kanal::{bounded_async, AsyncReceiver, AsyncSender, ReceiveError};
 use std::io;
@@ -130,10 +130,16 @@ impl Multiplexer {
         &self.buffer_pool
     }
 
-    /// Allocate a new stream ID atomically (lock-free)
+    /// Allocate a new stream ID atomically (lock-free).
+    ///
+    /// IDs advance by two to preserve client/server parity. Returns an error
+    /// rather than wrapping past `u32::MAX`, so an exhausted ID space can never
+    /// silently alias a live stream.
     #[inline]
-    fn allocate_stream_id(&self) -> u32 {
-        self.next_stream_id.fetch_add(2, Ordering::Relaxed)
+    fn allocate_stream_id(&self) -> Result<u32> {
+        self.next_stream_id
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |id| id.checked_add(2))
+            .map_err(|_| TunnelError::Protocol("stream ID space exhausted".into()))
     }
 
     /// Send a frame directly to the wire (priority derived from frame type and stream).
@@ -246,7 +252,7 @@ impl Multiplexer {
         protocol: Protocol,
         priority: StreamPriority,
     ) -> Result<VirtualStream> {
-        let stream_id = self.allocate_stream_id();
+        let stream_id = self.allocate_stream_id()?;
 
         let (tx, rx) = bounded_async(STREAM_CHANNEL_CAPACITY);
         self.streams.insert(stream_id, tx);

--- a/ferrotunnel-core/src/stream/quic_multiplexer.rs
+++ b/ferrotunnel-core/src/stream/quic_multiplexer.rs
@@ -123,9 +123,17 @@ impl QuicMultiplexer {
     }
 
     /// Allocate a new stream ID atomically.
-    fn allocate_stream_id(&self) -> u32 {
+    ///
+    /// Returns an error rather than wrapping past `u32::MAX` so an exhausted ID
+    /// space cannot silently alias a live stream.
+    fn allocate_stream_id(&self) -> Result<u32> {
         self.next_stream_id
-            .fetch_add(2, std::sync::atomic::Ordering::Relaxed)
+            .fetch_update(
+                std::sync::atomic::Ordering::Relaxed,
+                std::sync::atomic::Ordering::Relaxed,
+                |id| id.checked_add(2),
+            )
+            .map_err(|_| TunnelError::Protocol("stream ID space exhausted".into()))
     }
 
     /// Open a new outbound data stream.
@@ -143,7 +151,7 @@ impl QuicMultiplexer {
         protocol: Protocol,
         priority: StreamPriority,
     ) -> Result<QuicVirtualStream> {
-        let stream_id = self.allocate_stream_id();
+        let stream_id = self.allocate_stream_id()?;
 
         let (mut send, recv) = self
             .connection

--- a/ferrotunnel-http/Cargo.toml
+++ b/ferrotunnel-http/Cargo.toml
@@ -12,10 +12,10 @@ categories = ["network-programming", "web-programming"]
 description = "HTTP ingress and proxy implementation for FerroTunnel"
 
 [dependencies]
-ferrotunnel-core = { version = "1.4.0", path = "../ferrotunnel-core" }
-ferrotunnel-protocol = { version = "1.4.0", path = "../ferrotunnel-protocol" }
-ferrotunnel-plugin = { version = "1.4.0", path = "../ferrotunnel-plugin" }
-ferrotunnel-common = { version = "1.4.0", path = "../ferrotunnel-common" }
+ferrotunnel-core = { version = "1.5.0", path = "../ferrotunnel-core" }
+ferrotunnel-protocol = { version = "1.5.0", path = "../ferrotunnel-protocol" }
+ferrotunnel-plugin = { version = "1.5.0", path = "../ferrotunnel-plugin" }
+ferrotunnel-common = { version = "1.5.0", path = "../ferrotunnel-common" }
 tokio = { workspace = true }
 hyper = { version = "1", features = ["full", "http2"] }
 http-body-util = "0.1"
@@ -28,7 +28,7 @@ futures = "0.3"
 tower = { version = "0.5", features = ["full"] }
 tower-service = "0.3"
 thiserror = { workspace = true }
-ferrotunnel-observability = { version = "1.4.0", path = "../ferrotunnel-observability", optional = true }
+ferrotunnel-observability = { version = "1.5.0", path = "../ferrotunnel-observability", optional = true }
 h3 = { workspace = true, optional = true }
 h3-quinn = { workspace = true, optional = true }
 quinn = { workspace = true, optional = true }

--- a/ferrotunnel-http/src/http3_ingress.rs
+++ b/ferrotunnel-http/src/http3_ingress.rs
@@ -760,9 +760,7 @@ fn build_forward_request(
         parts.version = hyper::Version::HTTP_2;
         // hyper's H2 client does not add `TE: trailers`, which gRPC upstreams
         // need to return trailing metadata (grpc-status).
-        parts
-            .headers
-            .insert(hyper::header::TE, HeaderValue::from_static("trailers"));
+        crate::ingress::add_grpc_te_trailers(&mut parts.headers);
         if parts.uri.authority().is_none() {
             let path_and_query = parts
                 .uri

--- a/ferrotunnel-http/src/http3_ingress.rs
+++ b/ferrotunnel-http/src/http3_ingress.rs
@@ -23,7 +23,7 @@ use tracing::{error, info, warn};
 
 const H3_ALPN: &[u8] = b"h3";
 
-type BoxBody = http_body_util::combinators::BoxBody<Bytes, hyper::Error>;
+type BoxBody = http_body_util::combinators::BoxBody<Bytes, io::Error>;
 
 // Section 12.5: #[non_exhaustive] for semver-safe config evolution.
 // Construct via `Http3IngressConfig::default()` + struct update syntax.
@@ -789,12 +789,15 @@ fn streaming_body_to_boxbody(body: Http3RequestBody) -> BoxBody {
 
     let mut body = body;
     let frame_stream = poll_fn(
-        move |cx| -> Poll<Option<std::result::Result<Frame<Bytes>, hyper::Error>>> {
+        move |cx| -> Poll<Option<std::result::Result<Frame<Bytes>, io::Error>>> {
             match Pin::new(&mut body).poll_frame(cx) {
                 Poll::Ready(Some(Ok(frame))) => Poll::Ready(Some(Ok(frame))),
+                // Propagate the read error instead of converting it to a clean
+                // EOF, so the upstream sees a failed request body rather than a
+                // silently truncated one.
                 Poll::Ready(Some(Err(e))) => {
                     error!("HTTP/3 request body error: {e}");
-                    Poll::Ready(None)
+                    Poll::Ready(Some(Err(e)))
                 }
                 Poll::Ready(None) => Poll::Ready(None),
                 Poll::Pending => Poll::Pending,

--- a/ferrotunnel-http/src/http3_ingress.rs
+++ b/ferrotunnel-http/src/http3_ingress.rs
@@ -758,6 +758,11 @@ fn build_forward_request(
 
     if is_grpc {
         parts.version = hyper::Version::HTTP_2;
+        // hyper's H2 client does not add `TE: trailers`, which gRPC upstreams
+        // need to return trailing metadata (grpc-status).
+        parts
+            .headers
+            .insert(hyper::header::TE, HeaderValue::from_static("trailers"));
         if parts.uri.authority().is_none() {
             let path_and_query = parts
                 .uri

--- a/ferrotunnel-http/src/http3_ingress.rs
+++ b/ferrotunnel-http/src/http3_ingress.rs
@@ -751,8 +751,10 @@ fn build_forward_request(
     is_grpc: bool,
 ) -> std::result::Result<Request<BoxBody>, String> {
     let (mut parts, ()) = req.into_parts();
-    parts.headers.insert(HOST, host.clone());
+    // Sanitize hop-by-hop headers first, then insert the trusted canonical Host
+    // so a client-supplied `Connection: host` cannot drop it.
     crate::ingress::strip_hop_by_hop_headers(&mut parts.headers);
+    parts.headers.insert(HOST, host.clone());
 
     if is_grpc {
         parts.version = hyper::Version::HTTP_2;

--- a/ferrotunnel-http/src/http3_ingress.rs
+++ b/ferrotunnel-http/src/http3_ingress.rs
@@ -9,7 +9,7 @@ use h3::quic::{BidiStream, RecvStream, SendStream};
 use h3_quinn::quinn::{Endpoint, ServerConfig, TransportConfig, VarInt};
 use http_body_util::BodyExt;
 use hyper::body::Frame;
-use hyper::header::{HeaderName, HeaderValue, CONNECTION, HOST, TRANSFER_ENCODING, UPGRADE};
+use hyper::header::{HeaderName, HeaderValue, HOST};
 use hyper::{Request, Response, StatusCode, Uri};
 use hyper_util::rt::{TokioExecutor, TokioIo};
 use std::io;
@@ -752,7 +752,7 @@ fn build_forward_request(
 ) -> std::result::Result<Request<BoxBody>, String> {
     let (mut parts, ()) = req.into_parts();
     parts.headers.insert(HOST, host.clone());
-    remove_connection_specific_headers(&mut parts.headers);
+    crate::ingress::strip_hop_by_hop_headers(&mut parts.headers);
 
     if is_grpc {
         parts.version = hyper::Version::HTTP_2;
@@ -806,12 +806,6 @@ fn streaming_body_to_boxbody(body: Http3RequestBody) -> BoxBody {
     );
 
     StreamBody::new(frame_stream).boxed()
-}
-
-fn remove_connection_specific_headers(headers: &mut hyper::HeaderMap) {
-    headers.remove(CONNECTION);
-    headers.remove(TRANSFER_ENCODING);
-    headers.remove(UPGRADE);
 }
 
 // ---------------------------------------------------------------------------
@@ -968,7 +962,7 @@ async fn collect_upstream_body(
 fn sanitize_response_parts(
     mut parts: hyper::http::response::Parts,
 ) -> hyper::http::response::Parts {
-    remove_connection_specific_headers(&mut parts.headers);
+    crate::ingress::strip_hop_by_hop_headers(&mut parts.headers);
     parts
 }
 

--- a/ferrotunnel-http/src/ingress.rs
+++ b/ferrotunnel-http/src/ingress.rs
@@ -825,18 +825,31 @@ fn is_websocket_upgrade(headers: &hyper::HeaderMap) -> bool {
 /// smuggled header cannot leak to the upstream. Callers keep these headers for
 /// WebSocket upgrades, which legitimately negotiate over `Connection`/`Upgrade`.
 pub(crate) fn strip_hop_by_hop_headers(headers: &mut hyper::HeaderMap) {
+    // Remove any header named in the `Connection` value (RFC 7230 §6.1), except
+    // `Host`: it is end-to-end and required for strict host-based forwarding, so
+    // a `Connection: host` token must not be able to drop it.
     if let Some(connection) = headers.get(hyper::header::CONNECTION).cloned() {
         if let Ok(value) = connection.to_str() {
             for name in value.split(',') {
-                if let Ok(header) = hyper::header::HeaderName::from_bytes(name.trim().as_bytes()) {
+                let name = name.trim();
+                if name.is_empty() || name.eq_ignore_ascii_case("host") {
+                    continue;
+                }
+                if let Ok(header) = hyper::header::HeaderName::from_bytes(name.as_bytes()) {
                     headers.remove(header);
                 }
             }
         }
     }
+    // Remove the standard hop-by-hop headers.
     headers.remove(hyper::header::CONNECTION);
     headers.remove(hyper::header::TRANSFER_ENCODING);
     headers.remove(hyper::header::UPGRADE);
+    headers.remove(hyper::header::TE);
+    headers.remove(hyper::header::TRAILER);
+    headers.remove(hyper::header::PROXY_AUTHENTICATE);
+    headers.remove(hyper::header::PROXY_AUTHORIZATION);
+    headers.remove(hyper::header::HeaderName::from_static("keep-alive"));
 }
 
 /// Parse and normalize the Host header for secure multi-tenant routing.
@@ -1072,6 +1085,52 @@ mod tests {
         headers.insert(hyper::header::UPGRADE, "websocket".parse().unwrap());
         headers.insert(hyper::header::CONNECTION, "Upgrade".parse().unwrap());
         assert!(is_websocket_upgrade(&headers));
+    }
+
+    #[test]
+    fn strip_hop_by_hop_headers_removes_hop_by_hop_but_keeps_host() {
+        let mut headers = hyper::HeaderMap::new();
+        headers.insert(hyper::header::HOST, "tenant.example".parse().unwrap());
+        headers.insert(
+            hyper::header::CONNECTION,
+            "keep-alive, host, x-smuggle".parse().unwrap(),
+        );
+        headers.insert(hyper::header::TE, "trailers".parse().unwrap());
+        headers.insert(hyper::header::TRANSFER_ENCODING, "chunked".parse().unwrap());
+        headers.insert(
+            hyper::header::HeaderName::from_static("x-smuggle"),
+            "1".parse().unwrap(),
+        );
+        headers.insert(
+            hyper::header::HeaderName::from_static("keep-alive"),
+            "timeout=5".parse().unwrap(),
+        );
+        headers.insert(
+            hyper::header::HeaderName::from_static("x-end-to-end"),
+            "keep".parse().unwrap(),
+        );
+
+        strip_hop_by_hop_headers(&mut headers);
+
+        // Host survives even though it is named in Connection.
+        assert_eq!(headers.get(hyper::header::HOST).unwrap(), "tenant.example");
+        // A genuine end-to-end header is untouched.
+        assert_eq!(
+            headers
+                .get(hyper::header::HeaderName::from_static("x-end-to-end"))
+                .unwrap(),
+            "keep"
+        );
+        // Connection-listed and standard hop-by-hop headers are removed.
+        assert!(headers.get(hyper::header::CONNECTION).is_none());
+        assert!(headers.get(hyper::header::TE).is_none());
+        assert!(headers.get(hyper::header::TRANSFER_ENCODING).is_none());
+        assert!(headers
+            .get(hyper::header::HeaderName::from_static("x-smuggle"))
+            .is_none());
+        assert!(headers
+            .get(hyper::header::HeaderName::from_static("keep-alive"))
+            .is_none());
     }
 
     #[test]

--- a/ferrotunnel-http/src/ingress.rs
+++ b/ferrotunnel-http/src/ingress.rs
@@ -307,9 +307,7 @@ async fn handle_request(
     // Strip hop-by-hop headers before forwarding upstream, except for WebSocket
     // upgrades which legitimately rely on Connection/Upgrade to negotiate a 101.
     if !is_ws {
-        parts.headers.remove(hyper::header::CONNECTION);
-        parts.headers.remove(hyper::header::TRANSFER_ENCODING);
-        parts.headers.remove(hyper::header::UPGRADE);
+        strip_hop_by_hop_headers(&mut parts.headers);
     }
 
     let mut forward_req = Request::from_parts(parts, limited_body);
@@ -818,6 +816,27 @@ fn is_websocket_upgrade(headers: &hyper::HeaderMap) -> bool {
                 .any(|s| s.trim().eq_ignore_ascii_case("upgrade"))
         });
     upgrade && connection
+}
+
+/// Remove hop-by-hop headers before forwarding a request upstream.
+///
+/// Per RFC 7230 §6.1 this strips the fixed connection-management headers plus
+/// any header named in the `Connection` header value, so a connection-scoped or
+/// smuggled header cannot leak to the upstream. Callers keep these headers for
+/// WebSocket upgrades, which legitimately negotiate over `Connection`/`Upgrade`.
+pub(crate) fn strip_hop_by_hop_headers(headers: &mut hyper::HeaderMap) {
+    if let Some(connection) = headers.get(hyper::header::CONNECTION).cloned() {
+        if let Ok(value) = connection.to_str() {
+            for name in value.split(',') {
+                if let Ok(header) = hyper::header::HeaderName::from_bytes(name.trim().as_bytes()) {
+                    headers.remove(header);
+                }
+            }
+        }
+    }
+    headers.remove(hyper::header::CONNECTION);
+    headers.remove(hyper::header::TRANSFER_ENCODING);
+    headers.remove(hyper::header::UPGRADE);
 }
 
 /// Parse and normalize the Host header for secure multi-tenant routing.

--- a/ferrotunnel-http/src/ingress.rs
+++ b/ferrotunnel-http/src/ingress.rs
@@ -308,6 +308,14 @@ async fn handle_request(
     // upgrades which legitimately rely on Connection/Upgrade to negotiate a 101.
     if !is_ws {
         strip_hop_by_hop_headers(&mut parts.headers);
+        // gRPC over HTTP/2 requires `TE: trailers` for the upstream to return
+        // trailing metadata (grpc-status); hyper's H2 client does not add it, so
+        // restore it after stripping the hop-by-hop `TE` header.
+        if is_grpc {
+            parts
+                .headers
+                .insert(hyper::header::TE, HeaderValue::from_static("trailers"));
+        }
     }
 
     let mut forward_req = Request::from_parts(parts, limited_body);

--- a/ferrotunnel-http/src/ingress.rs
+++ b/ferrotunnel-http/src/ingress.rs
@@ -304,6 +304,14 @@ async fn handle_request(
         Arc::clone(&body_oversized),
     )
     .boxed();
+    // Strip hop-by-hop headers before forwarding upstream, except for WebSocket
+    // upgrades which legitimately rely on Connection/Upgrade to negotiate a 101.
+    if !is_ws {
+        parts.headers.remove(hyper::header::CONNECTION);
+        parts.headers.remove(hyper::header::TRANSFER_ENCODING);
+        parts.headers.remove(hyper::header::UPGRADE);
+    }
+
     let mut forward_req = Request::from_parts(parts, limited_body);
 
     // HTTP/2 (gRPC) requires an absolute URI (scheme + authority).
@@ -571,7 +579,33 @@ async fn handle_request(
         .execute_response_hooks(&mut proxy_res, &response_ctx)
         .await
     {
-        Ok(PluginAction::Continue | _) => {}
+        // Continue and Modify proceed with the (possibly in-place modified)
+        // response. Matching Reject and Respond exhaustively means a
+        // response-plugin decision is honored instead of silently dropped.
+        Ok(PluginAction::Continue | PluginAction::Modify { .. }) => {}
+        Ok(PluginAction::Reject { status, reason }) => {
+            return Ok(full_response(
+                StatusCode::from_u16(status).unwrap_or(StatusCode::FORBIDDEN),
+                &reason,
+            ));
+        }
+        Ok(PluginAction::Respond {
+            status,
+            headers,
+            body,
+        }) => {
+            let mut res =
+                Response::builder().status(StatusCode::from_u16(status).unwrap_or(StatusCode::OK));
+            for (k, v) in headers {
+                res = res.header(k, v);
+            }
+            return Ok(res.body(full_body(Bytes::from(body))).unwrap_or_else(|_| {
+                full_response(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "Failed to build plugin response",
+                )
+            }));
+        }
         // A hook error (including an isolated plugin panic, see #138) leaves
         // `proxy_res` holding the empty placeholder swapped in by the registry,
         // so we must not fall through and ship it. Return a clean 500 instead of
@@ -951,13 +985,6 @@ fn with_alt_svc_header(
         );
     }
     response
-}
-
-fn _empty_response(status: StatusCode) -> Response<BoxBody> {
-    Response::builder()
-        .status(status)
-        .body(Empty::new().map_err(|never| match never {}).boxed())
-        .unwrap_or_else(|_| Response::new(Empty::new().map_err(|never| match never {}).boxed()))
 }
 
 /// Check if error is a benign connection close to reduce log noise

--- a/ferrotunnel-http/src/ingress.rs
+++ b/ferrotunnel-http/src/ingress.rs
@@ -312,9 +312,7 @@ async fn handle_request(
         // trailing metadata (grpc-status); hyper's H2 client does not add it, so
         // restore it after stripping the hop-by-hop `TE` header.
         if is_grpc {
-            parts
-                .headers
-                .insert(hyper::header::TE, HeaderValue::from_static("trailers"));
+            add_grpc_te_trailers(&mut parts.headers);
         }
     }
 
@@ -858,6 +856,15 @@ pub(crate) fn strip_hop_by_hop_headers(headers: &mut hyper::HeaderMap) {
     headers.remove(hyper::header::PROXY_AUTHENTICATE);
     headers.remove(hyper::header::PROXY_AUTHORIZATION);
     headers.remove(hyper::header::HeaderName::from_static("keep-alive"));
+}
+
+/// Restore `TE: trailers` on a gRPC-over-HTTP/2 forward request.
+///
+/// gRPC upstreams require it to return trailing metadata (grpc-status), and
+/// hyper's H2 client does not add it. Call after hop-by-hop stripping, on the
+/// gRPC path only.
+pub(crate) fn add_grpc_te_trailers(headers: &mut hyper::HeaderMap) {
+    headers.insert(hyper::header::TE, HeaderValue::from_static("trailers"));
 }
 
 /// Parse and normalize the Host header for secure multi-tenant routing.

--- a/ferrotunnel-observability/Cargo.toml
+++ b/ferrotunnel-observability/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["network-programming"]
 include = ["src/**", "Cargo.toml", "README.md"]
 
 [dependencies]
-ferrotunnel-common = { version = "1.4.0", path = "../ferrotunnel-common" }
+ferrotunnel-common = { version = "1.5.0", path = "../ferrotunnel-common" }
 anyhow = { workspace = true }
 
 # Metrics

--- a/ferrotunnel-observability/src/lib.rs
+++ b/ferrotunnel-observability/src/lib.rs
@@ -16,10 +16,15 @@ pub fn init_basic_observability(service_name: &str, enable_tracing: bool, enable
     }
 
     if enable_tracing {
-        let _ = init_tracing(TracingConfig {
+        if let Err(e) = init_tracing(TracingConfig {
             service_name: service_name.to_string(),
             otlp_endpoint: std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT").ok(),
-        });
+        }) {
+            // Report the failure on stderr rather than silently continuing with
+            // no tracing subscriber installed (the tracing macros may not be
+            // wired up yet, so stderr is the reliable channel here).
+            eprintln!("Failed to initialize tracing/OTLP exporter: {e}");
+        }
     } else {
         init_minimal_logging();
     }

--- a/ferrotunnel-plugin/src/builtin/auth.rs
+++ b/ferrotunnel-plugin/src/builtin/auth.rs
@@ -64,9 +64,12 @@ impl Plugin for TokenAuthPlugin {
 
         match token {
             Some(t) if self.token_matches(t) => Ok(PluginAction::Continue),
+            // Use a generic reason so a missing token and a wrong token are
+            // indistinguishable to the client and the expected header name is
+            // not disclosed.
             _ => Ok(PluginAction::Reject {
                 status: 401,
-                reason: format!("Invalid or missing {}", self.header_name),
+                reason: "Invalid or missing authentication credentials".to_string(),
             }),
         }
     }

--- a/ferrotunnel-protocol/Cargo.toml
+++ b/ferrotunnel-protocol/Cargo.toml
@@ -10,7 +10,7 @@ description = "Wire protocol for FerroTunnel reverse tunnel"
 keywords = ["protocol", "tunnel", "networking"]
 
 [dependencies]
-ferrotunnel-common = { version = "1.4.0", path = "../ferrotunnel-common" }
+ferrotunnel-common = { version = "1.5.0", path = "../ferrotunnel-common" }
 serde = { workspace = true }
 bincode-next = { workspace = true }
 bytes = { workspace = true }

--- a/ferrotunnel-protocol/src/frame.rs
+++ b/ferrotunnel-protocol/src/frame.rs
@@ -61,14 +61,17 @@ pub struct OpenStreamFrame {
     pub priority: StreamPriority,
 }
 
-/// Handshake payload - boxed to reduce Frame enum size
+/// Handshake payload - boxed to reduce Frame enum size.
+///
+/// Invariant: `min_version <= max_version`. Frame validation rejects any
+/// handshake that violates it.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct HandshakeFrame {
     pub token: String,
     pub tunnel_id: Option<String>,
-    /// Minimum protocol version supported by this peer
+    /// Minimum protocol version supported by this peer (must be `<= max_version`).
     pub min_version: u8,
-    /// Maximum protocol version supported by this peer
+    /// Maximum protocol version supported by this peer (must be `>= min_version`).
     pub max_version: u8,
     pub capabilities: Vec<String>,
 }

--- a/ferrotunnel-protocol/src/validation.rs
+++ b/ferrotunnel-protocol/src/validation.rs
@@ -27,6 +27,9 @@ pub enum ValidationError {
 
     #[error("Field too long: {len} bytes exceeds limit of {limit} bytes")]
     FieldTooLong { len: usize, limit: usize },
+
+    #[error("Invalid version range: min_version {min} exceeds max_version {max}")]
+    InvalidVersionRange { min: u8, max: u8 },
 }
 
 /// Default cardinality and per-element size floors for control-frame contents.
@@ -154,6 +157,12 @@ fn validate_handshake(
     }
     if let Some(tunnel_id) = &handshake.tunnel_id {
         check_field_len(tunnel_id.len(), limits.max_name_len)?;
+    }
+    if handshake.min_version > handshake.max_version {
+        return Err(ValidationError::InvalidVersionRange {
+            min: handshake.min_version,
+            max: handshake.max_version,
+        });
     }
     validate_capabilities(&handshake.capabilities, limits)
 }
@@ -340,6 +349,22 @@ mod tests {
         assert!(matches!(
             validate_frame(&frame, &limits),
             Err(ValidationError::FieldTooLong { .. })
+        ));
+    }
+
+    #[test]
+    fn rejects_handshake_with_inverted_version_range() {
+        let limits = ValidationLimits::default();
+        let frame = Frame::Handshake(Box::new(crate::frame::HandshakeFrame {
+            token: "t".into(),
+            tunnel_id: None,
+            min_version: 2,
+            max_version: 1,
+            capabilities: Vec::new(),
+        }));
+        assert!(matches!(
+            validate_frame(&frame, &limits),
+            Err(ValidationError::InvalidVersionRange { min: 2, max: 1 })
         ));
     }
 

--- a/ferrotunnel/Cargo.toml
+++ b/ferrotunnel/Cargo.toml
@@ -12,11 +12,11 @@ keywords = ["tunnel", "reverse-proxy", "networking", "async"]
 categories = ["network-programming", "asynchronous"]
 
 [dependencies]
-ferrotunnel-common = { version = "1.4.0", path = "../ferrotunnel-common" }
-ferrotunnel-protocol = { version = "1.4.0", path = "../ferrotunnel-protocol" }
-ferrotunnel-core = { version = "1.4.0", path = "../ferrotunnel-core" }
-ferrotunnel-http = { version = "1.4.0", path = "../ferrotunnel-http" }
-ferrotunnel-plugin = { version = "1.4.0", path = "../ferrotunnel-plugin" }
+ferrotunnel-common = { version = "1.5.0", path = "../ferrotunnel-common" }
+ferrotunnel-protocol = { version = "1.5.0", path = "../ferrotunnel-protocol" }
+ferrotunnel-core = { version = "1.5.0", path = "../ferrotunnel-core" }
+ferrotunnel-http = { version = "1.5.0", path = "../ferrotunnel-http" }
+ferrotunnel-plugin = { version = "1.5.0", path = "../ferrotunnel-plugin" }
 
 # Re-export commonly used dependencies
 tokio = { workspace = true }

--- a/ferrotunnel/src/client.rs
+++ b/ferrotunnel/src/client.rs
@@ -13,7 +13,7 @@
 //!     .build()?;
 //!
 //! let info = client.start().await?;
-//! println!("Connected! Session: {:?}", info.session_id);
+//! println!("Connected! Session: {:?}", info.session_id());
 //! # Ok(())
 //! # }
 //! ```

--- a/ferrotunnel/src/client.rs
+++ b/ferrotunnel/src/client.rs
@@ -25,6 +25,7 @@ use ferrotunnel_core::transport::{tls::TlsTransportConfig, TransportConfig};
 use ferrotunnel_core::TunnelClient;
 use ferrotunnel_http::HttpProxy;
 use ferrotunnel_protocol::frame::Protocol;
+use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tokio::sync::{oneshot, watch};
@@ -51,6 +52,7 @@ pub struct Client {
 pub struct ClientBuilder {
     config: ClientConfig,
     transport_config: Option<TransportConfig>,
+    tls_validation_error: Option<TunnelError>,
 }
 
 impl Client {
@@ -370,8 +372,17 @@ impl ClientBuilder {
     /// When enabled, the client will use TLS to connect to the server.
     #[must_use]
     pub fn tls(mut self, config: &TlsConfig) -> Self {
-        if let Some(tls) = TlsTransportConfig::from_common(config) {
-            self.transport_config = Some(TransportConfig::Tls(tls));
+        match validate_client_tls_config(config) {
+            Ok(()) => {
+                self.tls_validation_error = None;
+                if let Some(tls) = TlsTransportConfig::from_common(config) {
+                    self.transport_config = Some(TransportConfig::Tls(tls));
+                }
+            }
+            Err(error) => {
+                self.tls_validation_error = Some(error);
+                self.transport_config = None;
+            }
         }
         self
     }
@@ -387,6 +398,7 @@ impl ClientBuilder {
         if let Some(quic) =
             ferrotunnel_core::transport::quic::QuicTransportConfig::from_common(config)
         {
+            self.tls_validation_error = None;
             self.transport_config = Some(TransportConfig::Quic(quic));
         }
         self
@@ -401,6 +413,9 @@ impl ClientBuilder {
     /// - `token` must be set
     pub fn build(self) -> Result<Client> {
         self.config.validate()?;
+        if let Some(error) = self.tls_validation_error {
+            return Err(error);
+        }
         Ok(Client {
             config: self.config,
             transport_config: self.transport_config.unwrap_or_default(),
@@ -410,9 +425,44 @@ impl ClientBuilder {
     }
 }
 
+fn validate_client_tls_config(config: &TlsConfig) -> Result<()> {
+    if !config.enabled {
+        return Err(TunnelError::Config(
+            "TLS config is disabled; omit ClientBuilder::tls() or enable TLS".into(),
+        ));
+    }
+
+    if missing_path(config.ca_cert_path.as_ref()) {
+        return Err(TunnelError::Config(
+            "client TLS requires ca_cert_path for server verification".into(),
+        ));
+    }
+
+    let has_cert = !missing_path(config.cert_path.as_ref());
+    let has_key = !missing_path(config.key_path.as_ref());
+    if config.client_auth && (!has_cert || !has_key) {
+        return Err(TunnelError::Config(
+            "client TLS client_auth requires cert_path and key_path".into(),
+        ));
+    }
+
+    if has_cert != has_key {
+        return Err(TunnelError::Config(
+            "client TLS certificate and key paths must be provided together".into(),
+        ));
+    }
+
+    Ok(())
+}
+
+fn missing_path(path: Option<&PathBuf>) -> bool {
+    path.is_none_or(|path| path.as_os_str().is_empty())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::PathBuf;
 
     #[test]
     fn test_client_builder_success() {
@@ -528,14 +578,88 @@ mod tests {
             enabled: false,
             ..Default::default()
         };
+        let result = Client::builder()
+            .server_addr("localhost:7835")
+            .token("secret")
+            .tls(&tls)
+            .build();
+
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("TLS config is disabled"));
+    }
+
+    #[test]
+    fn test_client_builder_tls_missing_ca() {
+        let tls = TlsConfig {
+            enabled: true,
+            ..Default::default()
+        };
+        let result = Client::builder()
+            .server_addr("localhost:7835")
+            .token("secret")
+            .tls(&tls)
+            .build();
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("ca_cert_path"));
+    }
+
+    #[test]
+    fn test_client_builder_tls_rejects_partial_client_auth_material() {
+        let tls = TlsConfig {
+            enabled: true,
+            ca_cert_path: Some(PathBuf::from("ca.pem")),
+            cert_path: Some(PathBuf::from("client.pem")),
+            ..Default::default()
+        };
+        let result = Client::builder()
+            .server_addr("localhost:7835")
+            .token("secret")
+            .tls(&tls)
+            .build();
+
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("provided together"));
+    }
+
+    #[test]
+    fn test_client_builder_tls_rejects_client_auth_without_material() {
+        let tls = TlsConfig {
+            enabled: true,
+            ca_cert_path: Some(PathBuf::from("ca.pem")),
+            client_auth: true,
+            ..Default::default()
+        };
+        let result = Client::builder()
+            .server_addr("localhost:7835")
+            .token("secret")
+            .tls(&tls)
+            .build();
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("client_auth"));
+    }
+
+    #[test]
+    fn test_client_builder_tls_ca_only() {
+        let tls = TlsConfig {
+            enabled: true,
+            ca_cert_path: Some(PathBuf::from("ca.pem")),
+            ..Default::default()
+        };
         let client = Client::builder()
             .server_addr("localhost:7835")
             .token("secret")
             .tls(&tls)
             .build()
-            .expect("should build");
+            .expect("server-auth TLS should not require client certificate material");
 
-        // TLS disabled means no transport config set
         assert!(!client.config().server_addr.is_empty());
     }
 }

--- a/ferrotunnel/src/client.rs
+++ b/ferrotunnel/src/client.rs
@@ -69,6 +69,7 @@ impl Client {
     ///     .build()
     ///     .unwrap();
     /// ```
+    #[must_use]
     pub fn builder() -> ClientBuilder {
         ClientBuilder::default()
     }

--- a/ferrotunnel/src/client.rs
+++ b/ferrotunnel/src/client.rs
@@ -433,7 +433,10 @@ fn validate_client_tls_config(config: &TlsConfig) -> Result<()> {
         ));
     }
 
-    if missing_path(config.ca_cert_path.as_ref()) {
+    // `skip_verify` disables server-certificate verification, so no CA is
+    // required (this matches what `create_client_config` accepts). Only require
+    // a CA when the server certificate will actually be verified.
+    if !config.skip_verify && missing_path(config.ca_cert_path.as_ref()) {
         return Err(TunnelError::Config(
             "client TLS requires ca_cert_path for server verification".into(),
         ));
@@ -660,6 +663,25 @@ mod tests {
             .tls(&tls)
             .build()
             .expect("server-auth TLS should not require client certificate material");
+
+        assert!(!client.config().server_addr.is_empty());
+    }
+
+    #[test]
+    fn test_client_builder_tls_skip_verify_without_ca() {
+        // `skip_verify` disables server verification, so a CA is not required;
+        // the transport supports this, so `build()` must accept it.
+        let tls = TlsConfig {
+            enabled: true,
+            skip_verify: true,
+            ..Default::default()
+        };
+        let client = Client::builder()
+            .server_addr("localhost:7835")
+            .token("secret")
+            .tls(&tls)
+            .build()
+            .expect("skip_verify TLS should not require a CA path");
 
         assert!(!client.config().server_addr.is_empty());
     }

--- a/ferrotunnel/src/config.rs
+++ b/ferrotunnel/src/config.rs
@@ -2,44 +2,58 @@
 //!
 //! These types provide type-safe configuration for embedding `FerroTunnel`
 //! in your applications.
+//!
+//! Config fields are private; construct these types through
+//! [`ClientBuilder`](crate::ClientBuilder) / [`ServerBuilder`](crate::ServerBuilder)
+//! and read them back through the getters. This keeps the authentication token
+//! out of derived `Debug` output and lets new fields be added without breaking
+//! callers.
 
 use ferrotunnel_common::{
     LimitsConfig, Result, TunnelError, DEFAULT_HTTP_PORT, DEFAULT_LOCAL_ADDR, DEFAULT_TUNNEL_PORT,
 };
 use ferrotunnel_core::validate_limits;
+use std::fmt;
 use std::net::SocketAddr;
+#[cfg(feature = "http3")]
+use std::path::Path;
 #[cfg(feature = "http3")]
 use std::path::PathBuf;
 use std::time::Duration;
 
+/// Placeholder shown in place of the authentication token in `Debug` output.
+const REDACTED: &str = "<redacted>";
+
 /// Configuration for the tunnel client.
 ///
-/// Use [`ClientBuilder`](crate::ClientBuilder) for ergonomic construction.
-#[derive(Debug, Clone)]
+/// Use [`ClientBuilder`](crate::ClientBuilder) for ergonomic construction, then
+/// read values back through the getters. The `Debug` implementation redacts the
+/// authentication token.
+#[derive(Clone)]
 pub struct ClientConfig {
     /// Server address to connect to (host:port)
-    pub server_addr: String,
+    pub(crate) server_addr: String,
 
     /// Authentication token
-    pub token: String,
+    pub(crate) token: String,
 
     /// Local address to forward traffic to
-    pub local_addr: String,
+    pub(crate) local_addr: String,
 
     /// Tunnel ID used for HTTP routing (matched against the Host header)
-    pub tunnel_id: Option<String>,
+    pub(crate) tunnel_id: Option<String>,
 
     /// Enable automatic reconnection on disconnect
-    pub auto_reconnect: bool,
+    pub(crate) auto_reconnect: bool,
 
     /// Delay between reconnection attempts
-    pub reconnect_delay: Duration,
+    pub(crate) reconnect_delay: Duration,
 
     /// Maximum time to wait for the initial connection in `start()`. `None` waits indefinitely. Default 30s.
-    pub startup_timeout: Option<Duration>,
+    pub(crate) startup_timeout: Option<Duration>,
 
     /// Resource limits for protocol framing and connection handling.
-    pub limits: LimitsConfig,
+    pub(crate) limits: LimitsConfig,
 }
 
 impl ClientConfig {
@@ -56,6 +70,61 @@ impl ClientConfig {
         }
         validate_limits(&self.limits)?;
         Ok(())
+    }
+
+    /// Server address the client connects to (`host:port`).
+    pub fn server_addr(&self) -> &str {
+        &self.server_addr
+    }
+
+    /// Authentication token presented to the server.
+    pub fn token(&self) -> &str {
+        &self.token
+    }
+
+    /// Local address traffic is forwarded to.
+    pub fn local_addr(&self) -> &str {
+        &self.local_addr
+    }
+
+    /// Tunnel ID used for HTTP routing, if set.
+    pub fn tunnel_id(&self) -> Option<&str> {
+        self.tunnel_id.as_deref()
+    }
+
+    /// Whether automatic reconnection is enabled.
+    pub fn auto_reconnect(&self) -> bool {
+        self.auto_reconnect
+    }
+
+    /// Delay between reconnection attempts.
+    pub fn reconnect_delay(&self) -> Duration {
+        self.reconnect_delay
+    }
+
+    /// Maximum time `start()` waits for the initial connection. `None` waits indefinitely.
+    pub fn startup_timeout(&self) -> Option<Duration> {
+        self.startup_timeout
+    }
+
+    /// Resource limits for protocol framing and connection handling.
+    pub fn limits(&self) -> &LimitsConfig {
+        &self.limits
+    }
+}
+
+impl fmt::Debug for ClientConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ClientConfig")
+            .field("server_addr", &self.server_addr)
+            .field("token", &REDACTED)
+            .field("local_addr", &self.local_addr)
+            .field("tunnel_id", &self.tunnel_id)
+            .field("auto_reconnect", &self.auto_reconnect)
+            .field("reconnect_delay", &self.reconnect_delay)
+            .field("startup_timeout", &self.startup_timeout)
+            .field("limits", &self.limits)
+            .finish()
     }
 }
 
@@ -76,32 +145,34 @@ impl Default for ClientConfig {
 
 /// Configuration for the tunnel server.
 ///
-/// Use [`ServerBuilder`](crate::ServerBuilder) for ergonomic construction.
-#[derive(Debug, Clone)]
+/// Use [`ServerBuilder`](crate::ServerBuilder) for ergonomic construction, then
+/// read values back through the getters. The `Debug` implementation redacts the
+/// authentication token.
+#[derive(Clone)]
 pub struct ServerConfig {
     /// Address to bind the tunnel control plane
-    pub bind_addr: SocketAddr,
+    pub(crate) bind_addr: SocketAddr,
 
     /// Address to bind the HTTP ingress
-    pub http_bind_addr: SocketAddr,
+    pub(crate) http_bind_addr: SocketAddr,
 
     /// Optional address to bind HTTP/3 ingress (UDP)
     #[cfg(feature = "http3")]
-    pub http3_bind_addr: Option<SocketAddr>,
+    pub(crate) http3_bind_addr: Option<SocketAddr>,
 
     /// Path to certificate file for HTTP/3 ingress
     #[cfg(feature = "http3")]
-    pub http3_cert_path: Option<PathBuf>,
+    pub(crate) http3_cert_path: Option<PathBuf>,
 
     /// Path to private key file for HTTP/3 ingress
     #[cfg(feature = "http3")]
-    pub http3_key_path: Option<PathBuf>,
+    pub(crate) http3_key_path: Option<PathBuf>,
 
     /// Authentication token (clients must provide this)
-    pub token: String,
+    pub(crate) token: String,
 
     /// Resource limits for protocol framing and connection handling.
-    pub limits: LimitsConfig,
+    pub(crate) limits: LimitsConfig,
 }
 
 impl ServerConfig {
@@ -120,6 +191,62 @@ impl ServerConfig {
             ));
         }
         Ok(())
+    }
+
+    /// Address the tunnel control plane binds to.
+    pub fn bind_addr(&self) -> SocketAddr {
+        self.bind_addr
+    }
+
+    /// Address the HTTP ingress binds to.
+    pub fn http_bind_addr(&self) -> SocketAddr {
+        self.http_bind_addr
+    }
+
+    /// Address the HTTP/3 ingress binds to, if configured.
+    #[cfg(feature = "http3")]
+    pub fn http3_bind_addr(&self) -> Option<SocketAddr> {
+        self.http3_bind_addr
+    }
+
+    /// Certificate path for the HTTP/3 ingress, if configured.
+    #[cfg(feature = "http3")]
+    pub fn http3_cert_path(&self) -> Option<&Path> {
+        self.http3_cert_path.as_deref()
+    }
+
+    /// Private-key path for the HTTP/3 ingress, if configured.
+    #[cfg(feature = "http3")]
+    pub fn http3_key_path(&self) -> Option<&Path> {
+        self.http3_key_path.as_deref()
+    }
+
+    /// Authentication token clients must present.
+    pub fn token(&self) -> &str {
+        &self.token
+    }
+
+    /// Resource limits for protocol framing and connection handling.
+    pub fn limits(&self) -> &LimitsConfig {
+        &self.limits
+    }
+}
+
+impl fmt::Debug for ServerConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut debug = f.debug_struct("ServerConfig");
+        debug
+            .field("bind_addr", &self.bind_addr)
+            .field("http_bind_addr", &self.http_bind_addr);
+        #[cfg(feature = "http3")]
+        debug
+            .field("http3_bind_addr", &self.http3_bind_addr)
+            .field("http3_cert_path", &self.http3_cert_path)
+            .field("http3_key_path", &self.http3_key_path);
+        debug
+            .field("token", &REDACTED)
+            .field("limits", &self.limits)
+            .finish()
     }
 }
 
@@ -141,16 +268,35 @@ impl Default for ServerConfig {
 }
 
 /// Information about an established tunnel connection.
+///
+/// Returned by `Client::start()`. Read the fields through the getters.
 #[derive(Debug, Clone)]
 pub struct TunnelInfo {
     /// The session ID assigned by the server.
     ///
-    /// Note: Currently this is a client-generated placeholder until
-    /// the core library exposes the server-assigned session ID.
-    pub session_id: Option<uuid::Uuid>,
+    /// Currently a client-generated placeholder until the core library exposes
+    /// the server-assigned session ID.
+    pub(crate) session_id: Option<uuid::Uuid>,
 
-    /// The public URL where the tunnel is accessible (if applicable)
-    pub public_url: Option<String>,
+    /// Reserved for the public URL where the tunnel is reachable.
+    ///
+    /// Not yet populated: `public_url()` currently always returns `None`. It is
+    /// kept so callers can adopt the accessor before the value is wired up.
+    pub(crate) public_url: Option<String>,
+}
+
+impl TunnelInfo {
+    /// The session ID for the established tunnel, if assigned.
+    pub fn session_id(&self) -> Option<uuid::Uuid> {
+        self.session_id
+    }
+
+    /// The public URL where the tunnel is reachable.
+    ///
+    /// Reserved for future use; currently always `None`.
+    pub fn public_url(&self) -> Option<&str> {
+        self.public_url.as_deref()
+    }
 }
 
 #[cfg(test)]
@@ -244,6 +390,37 @@ mod tests {
     }
 
     #[test]
+    fn test_client_config_getters() {
+        let config = ClientConfig {
+            server_addr: "localhost:7835".to_string(),
+            token: "secret".to_string(),
+            local_addr: "127.0.0.1:8080".to_string(),
+            tunnel_id: Some("my-tunnel".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(config.server_addr(), "localhost:7835");
+        assert_eq!(config.token(), "secret");
+        assert_eq!(config.local_addr(), "127.0.0.1:8080");
+        assert_eq!(config.tunnel_id(), Some("my-tunnel"));
+        assert!(config.auto_reconnect());
+        assert_eq!(config.reconnect_delay(), Duration::from_secs(5));
+        assert_eq!(config.startup_timeout(), Some(Duration::from_secs(30)));
+        assert_eq!(config.limits().max_frame_bytes, 16 * 1024 * 1024);
+    }
+
+    #[test]
+    fn test_client_config_debug_redacts_token() {
+        let config = ClientConfig {
+            server_addr: "localhost:7835".to_string(),
+            token: "super-secret-token".to_string(),
+            ..Default::default()
+        };
+        let rendered = format!("{config:?}");
+        assert!(!rendered.contains("super-secret-token"));
+        assert!(rendered.contains("<redacted>"));
+    }
+
+    #[test]
     fn test_server_config_default() {
         let config = ServerConfig::default();
         assert_eq!(config.bind_addr, SocketAddr::from(([0, 0, 0, 0], 7835)));
@@ -295,13 +472,39 @@ mod tests {
     }
 
     #[test]
+    fn test_server_config_getters() {
+        let config = ServerConfig {
+            token: "secret".to_string(),
+            ..Default::default()
+        };
+        assert_eq!(config.bind_addr(), SocketAddr::from(([0, 0, 0, 0], 7835)));
+        assert_eq!(
+            config.http_bind_addr(),
+            SocketAddr::from(([0, 0, 0, 0], 8080))
+        );
+        assert_eq!(config.token(), "secret");
+        assert_eq!(config.limits().max_frame_bytes, 16 * 1024 * 1024);
+    }
+
+    #[test]
+    fn test_server_config_debug_redacts_token() {
+        let config = ServerConfig {
+            token: "super-secret-token".to_string(),
+            ..Default::default()
+        };
+        let rendered = format!("{config:?}");
+        assert!(!rendered.contains("super-secret-token"));
+        assert!(rendered.contains("<redacted>"));
+    }
+
+    #[test]
     fn test_tunnel_info_none_values() {
         let info = TunnelInfo {
             session_id: None,
             public_url: None,
         };
-        assert!(info.session_id.is_none());
-        assert!(info.public_url.is_none());
+        assert!(info.session_id().is_none());
+        assert!(info.public_url().is_none());
     }
 
     #[test]
@@ -311,10 +514,7 @@ mod tests {
             session_id: Some(uuid),
             public_url: Some("https://tunnel.example.com".to_string()),
         };
-        assert_eq!(info.session_id, Some(uuid));
-        assert_eq!(
-            info.public_url,
-            Some("https://tunnel.example.com".to_string())
-        );
+        assert_eq!(info.session_id(), Some(uuid));
+        assert_eq!(info.public_url(), Some("https://tunnel.example.com"));
     }
 }

--- a/ferrotunnel/src/lib.rs
+++ b/ferrotunnel/src/lib.rs
@@ -26,7 +26,7 @@
 //!         .build()?;
 //!
 //!     let info = client.start().await?;
-//!     println!("Connected! Session: {:?}", info.session_id);
+//!     println!("Connected! Session: {:?}", info.session_id());
 //!
 //!     // Keep running until Ctrl+C
 //!     tokio::signal::ctrl_c().await?;
@@ -75,10 +75,17 @@ pub mod client;
 pub mod config;
 pub mod server;
 
-// Re-export subcrates
+// Re-export the shared vocabulary crate (errors, `Result`, config types).
 pub use ferrotunnel_common as common;
+
+// Implementation crates are re-exported for advanced use but are not part of
+// the stable public API surface, so they are hidden from the generated docs.
+// The prelude re-exports the specific protocol types intended for public use.
+#[doc(hidden)]
 pub use ferrotunnel_core as core;
+#[doc(hidden)]
 pub use ferrotunnel_http as http;
+#[doc(hidden)]
 pub use ferrotunnel_protocol as protocol;
 
 // Public API exports

--- a/ferrotunnel/src/server.rs
+++ b/ferrotunnel/src/server.rs
@@ -30,7 +30,6 @@ use ferrotunnel_http::HttpIngress;
 use ferrotunnel_http::{Http3Ingress, Http3IngressConfig};
 use ferrotunnel_plugin::PluginRegistry;
 use std::net::SocketAddr;
-#[cfg(feature = "http3")]
 use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::{watch, RwLock};
@@ -53,6 +52,7 @@ pub struct Server {
 pub struct ServerBuilder {
     config: ServerConfig,
     transport_config: Option<TransportConfig>,
+    tls_validation_error: Option<TunnelError>,
 }
 
 impl Server {
@@ -357,8 +357,17 @@ impl ServerBuilder {
     /// When enabled, the server will use TLS for all connections.
     #[must_use]
     pub fn tls(mut self, config: &TlsConfig) -> Self {
-        if let Some(tls) = TlsTransportConfig::from_common(config) {
-            self.transport_config = Some(TransportConfig::Tls(tls));
+        match validate_server_tls_config(config) {
+            Ok(()) => {
+                self.tls_validation_error = None;
+                if let Some(tls) = TlsTransportConfig::from_common(config) {
+                    self.transport_config = Some(TransportConfig::Tls(tls));
+                }
+            }
+            Err(error) => {
+                self.tls_validation_error = Some(error);
+                self.transport_config = None;
+            }
         }
         self
     }
@@ -383,6 +392,7 @@ impl ServerBuilder {
         if let Some(quic) =
             ferrotunnel_core::transport::quic::QuicTransportConfig::from_common(config)
         {
+            self.tls_validation_error = None;
             self.transport_config = Some(TransportConfig::Quic(quic));
         }
         self
@@ -396,6 +406,9 @@ impl ServerBuilder {
     /// - `token` must be set
     pub fn build(self) -> Result<Server> {
         self.config.validate()?;
+        if let Some(error) = self.tls_validation_error {
+            return Err(error);
+        }
         Ok(Server {
             config: self.config,
             transport_config: self.transport_config.unwrap_or_default(),
@@ -403,6 +416,34 @@ impl ServerBuilder {
             task: None,
         })
     }
+}
+
+fn validate_server_tls_config(config: &TlsConfig) -> Result<()> {
+    if !config.enabled {
+        return Err(TunnelError::Config(
+            "TLS config is disabled; omit ServerBuilder::tls() or enable TLS".into(),
+        ));
+    }
+
+    if missing_path(config.cert_path.as_ref()) {
+        return Err(TunnelError::Config("server TLS requires cert_path".into()));
+    }
+
+    if missing_path(config.key_path.as_ref()) {
+        return Err(TunnelError::Config("server TLS requires key_path".into()));
+    }
+
+    if config.client_auth && missing_path(config.ca_cert_path.as_ref()) {
+        return Err(TunnelError::Config(
+            "server TLS client_auth requires ca_cert_path".into(),
+        ));
+    }
+
+    Ok(())
+}
+
+fn missing_path(path: Option<&PathBuf>) -> bool {
+    path.is_none_or(|path| path.as_os_str().is_empty())
 }
 
 #[cfg(test)]
@@ -505,13 +546,70 @@ mod tests {
             enabled: false,
             ..Default::default()
         };
+        let result = Server::builder().token("secret").tls(&tls).build();
+
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("TLS config is disabled"));
+    }
+
+    #[test]
+    fn test_server_builder_tls_missing_cert() {
+        let tls = TlsConfig {
+            enabled: true,
+            key_path: Some(PathBuf::from("server.key")),
+            ..Default::default()
+        };
+        let result = Server::builder().token("secret").tls(&tls).build();
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("cert_path"));
+    }
+
+    #[test]
+    fn test_server_builder_tls_missing_key() {
+        let tls = TlsConfig {
+            enabled: true,
+            cert_path: Some(PathBuf::from("server.crt")),
+            ..Default::default()
+        };
+        let result = Server::builder().token("secret").tls(&tls).build();
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("key_path"));
+    }
+
+    #[test]
+    fn test_server_builder_tls_client_auth_missing_ca() {
+        let tls = TlsConfig {
+            enabled: true,
+            cert_path: Some(PathBuf::from("server.crt")),
+            key_path: Some(PathBuf::from("server.key")),
+            client_auth: true,
+            ..Default::default()
+        };
+        let result = Server::builder().token("secret").tls(&tls).build();
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("ca_cert_path"));
+    }
+
+    #[test]
+    fn test_server_builder_tls_with_cert_and_key() {
+        let tls = TlsConfig {
+            enabled: true,
+            cert_path: Some(PathBuf::from("server.crt")),
+            key_path: Some(PathBuf::from("server.key")),
+            ..Default::default()
+        };
         let server = Server::builder()
             .token("secret")
             .tls(&tls)
             .build()
-            .expect("should build");
+            .expect("server-auth TLS should accept certificate and key paths");
 
-        // Server should work with TLS disabled
         assert!(!server.config().token.is_empty());
     }
 }

--- a/ferrotunnel/src/server.rs
+++ b/ferrotunnel/src/server.rs
@@ -69,6 +69,7 @@ impl Server {
     ///     .build()
     ///     .unwrap();
     /// ```
+    #[must_use]
     pub fn builder() -> ServerBuilder {
         ServerBuilder::default()
     }

--- a/tests/integration/concurrent_test.rs
+++ b/tests/integration/concurrent_test.rs
@@ -27,7 +27,7 @@ async fn test_concurrent_requests() {
         .expect("Failed to build client");
 
     let info = client.start().await.expect("Client failed to connect");
-    let session_id = info.session_id.expect("Session ID required").to_string();
+    let session_id = info.session_id().expect("Session ID required").to_string();
 
     tokio::time::sleep(Duration::from_millis(500)).await;
 

--- a/tests/integration/error_test.rs
+++ b/tests/integration/error_test.rs
@@ -22,7 +22,7 @@ async fn test_upstream_connection_refused() {
         .expect("Failed to build client");
 
     let info = client.start().await.expect("Client failed to connect");
-    let session_id = info.session_id.expect("Session ID required").to_string();
+    let session_id = info.session_id().expect("Session ID required").to_string();
 
     tokio::time::sleep(Duration::from_millis(500)).await;
 

--- a/tests/integration/grpc_test.rs
+++ b/tests/integration/grpc_test.rs
@@ -111,7 +111,7 @@ async fn test_grpc_tunnel() {
 
     let info = client.start().await.expect("Client failed to connect");
     let session_id = info
-        .session_id
+        .session_id()
         .expect("Session ID should be present")
         .to_string();
 
@@ -257,7 +257,7 @@ async fn test_non_grpc_not_classified_as_grpc() {
 
     let info = client.start().await.expect("Client failed to connect");
     let session_id = info
-        .session_id
+        .session_id()
         .expect("Session ID should be present")
         .to_string();
 

--- a/tests/integration/multi_client_test.rs
+++ b/tests/integration/multi_client_test.rs
@@ -43,7 +43,7 @@ async fn test_multiple_clients() {
 
     // Verify both clients have unique session IDs
     assert_ne!(
-        info1.session_id, info2.session_id,
+        info1.session_id(), info2.session_id(),
         "Clients should have different session IDs"
     );
 
@@ -72,7 +72,7 @@ async fn test_client_reconnect() {
         .expect("Failed to build client");
 
     let info1 = client.start().await.expect("First connect failed");
-    let session1 = info1.session_id;
+    let session1 = info1.session_id();
 
     // Disconnect
     let _ = client.shutdown().await;
@@ -92,7 +92,7 @@ async fn test_client_reconnect() {
 
     // New connection should have different session
     assert_ne!(
-        session1, info2.session_id,
+        session1, info2.session_id(),
         "Reconnect should get new session"
     );
 

--- a/tests/integration/multi_client_test.rs
+++ b/tests/integration/multi_client_test.rs
@@ -43,7 +43,8 @@ async fn test_multiple_clients() {
 
     // Verify both clients have unique session IDs
     assert_ne!(
-        info1.session_id(), info2.session_id(),
+        info1.session_id(),
+        info2.session_id(),
         "Clients should have different session IDs"
     );
 
@@ -92,7 +93,8 @@ async fn test_client_reconnect() {
 
     // New connection should have different session
     assert_ne!(
-        session1, info2.session_id(),
+        session1,
+        info2.session_id(),
         "Reconnect should get new session"
     );
 

--- a/tests/integration/tunnel_test.rs
+++ b/tests/integration/tunnel_test.rs
@@ -48,7 +48,7 @@ async fn test_client_connects() {
     // Verify client got a session
     let tunnel_info = info.unwrap();
     assert!(
-        tunnel_info.session_id.is_some(),
+        tunnel_info.session_id().is_some(),
         "Session ID should not be empty"
     );
 
@@ -77,7 +77,7 @@ async fn test_http_through_tunnel() {
 
     let info = client.start().await.expect("Client failed to connect");
     let session_id = info
-        .session_id
+        .session_id()
         .expect("Session ID should be present")
         .to_string();
 
@@ -131,7 +131,7 @@ async fn test_large_payload() {
 
     let info = client.start().await.expect("Client failed to connect");
     let session_id = info
-        .session_id
+        .session_id()
         .expect("Session ID should be present")
         .to_string();
 

--- a/tests/integration/websocket_test.rs
+++ b/tests/integration/websocket_test.rs
@@ -70,7 +70,7 @@ async fn test_websocket_upgrade_through_tunnel() {
 
     let info = client.start().await.expect("Client failed to connect");
     let session_id = info
-        .session_id
+        .session_id()
         .expect("Session ID should be present")
         .to_string();
 
@@ -166,7 +166,7 @@ async fn test_websocket_raw_upgrade_101() {
 
     let info = client.start().await.expect("Client failed to connect");
     let session_id = info
-        .session_id
+        .session_id()
         .expect("Session ID should be present")
         .to_string();
 
@@ -270,7 +270,7 @@ async fn test_websocket_subprotocol_preserved() {
         .expect("Failed to build client");
 
     let info = client.start().await.expect("Client failed to connect");
-    let session_id = info.session_id.unwrap().to_string();
+    let session_id = info.session_id().unwrap().to_string();
 
     let ws_url = format!("ws://127.0.0.1:{http_port}/ws");
     let mut request = ws_url.into_client_request().unwrap();
@@ -323,7 +323,7 @@ async fn test_websocket_multiple_concurrent_streams() {
         .expect("Failed to build client");
 
     let info = client.start().await.expect("Client failed to connect");
-    let session_id = info.session_id.unwrap().to_string();
+    let session_id = info.session_id().unwrap().to_string();
 
     let mut handles = Vec::new();
     for i in 0..10 {
@@ -415,7 +415,7 @@ async fn test_websocket_failed_upgrade_404() {
         .expect("Failed to build client");
 
     let info = client.start().await.expect("Client failed to connect");
-    let session_id = info.session_id.unwrap().to_string();
+    let session_id = info.session_id().unwrap().to_string();
 
     let ws_url = format!("ws://127.0.0.1:{http_port}/ws");
     let mut request =

--- a/tools/soak/Cargo.toml
+++ b/tools/soak/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 publish = false
 
 [dependencies]
-ferrotunnel = { version = "1.4.0", path = "../../ferrotunnel" }
+ferrotunnel = { version = "1.5.0", path = "../../ferrotunnel" }
 tokio = { workspace = true }
 clap = { version = "4", features = ["derive"] }
 anyhow = { workspace = true }


### PR DESCRIPTION
## Summary

FerroTunnel 1.5.0 closes the **v1.5.0** milestone (#140, #141) and part of the
**v1.5.x** audit backlog (#122, #123, #142, and a curated subset of #145). It
tightens the public API surface, redacts secrets, and fixes a set of verified
ingress, protocol, and observability correctness issues.

## ⚠ Breaking change

Configuration types are now encapsulated (#140). `ClientConfig`, `ServerConfig`,
and `TunnelInfo` fields are private with public getters — read them back via
accessors (`config.token()`, `info.session_id()`, …) and construct through
`Client::builder()` / `Server::builder()`. This prevents post-`build()` mutation
and keeps the authentication token out of `Debug` output. Shipped in a minor
(1.5.0) by intent; the CHANGELOG carries a Breaking-changes callout.

## Included

**v1.5.0 milestone**
- Closes #141 — builder TLS config fails loudly at `build()` time
- Closes #140 — encapsulate config fields, redact token in `Debug`, hide implementation-crate re-exports

**v1.5.x audit items**
- Closes #142 — CLI validation error propagates instead of `std::process::exit`
- Closes #123 — advertised MSRV aligned to 1.91 (README, CONTRIBUTING, CLI, Dockerfile)
- Closes #122 — unify the duplicate `rand` dependency on 0.9, document the `cargo-deny` duplicate-version policy

**Curated #145 (umbrella stays open)** — the verified real bugs:
- HTTP/1 response-plugin `Reject`/`Respond` now honored (was a silent no-op)
- HTTP/1 hop-by-hop header stripping (parity with HTTP/3; preserved for WebSocket upgrades)
- HTTP/3 request-body read errors propagated (no silent truncation)
- Stream-ID allocation fails on overflow instead of aliasing a live stream
- Token-auth 401 no longer leaks the expected header name
- Request replay captures the full path + query
- Tracing/OTLP init failures reported instead of swallowed
- `HandshakeFrame` `min_version <= max_version` invariant enforced
- Builders marked `#[must_use]`; `burst_factor` bound documented

Deferred to v1.5.x (noted on #145): the per-frame heartbeat write-lock
optimization (needs a `Session` refactor) and `--log-level` wiring (needs an
observability-API change), plus the remaining Low-severity nits.

## Attribution

The #141 and #142 fixes are authored by @wondr-wclabs, integrated from PRs #153
and #146 (superseded by this branch); the commits keep `Co-authored-by` trailers
so the attribution survives the squash-merge.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- [x] `cargo test --workspace --all-features` — all unit + 26 integration + 6 doctests pass
- [x] `make audit` — advisories / bans / licenses / sources ok
- [ ] CI green on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added **v1.5.0** release notes.
  * Dashboard request path capture now preserves the full path **including query strings**.
* **Bug Fixes**
  * TLS configuration is validated earlier in CLI/builders with clearer surfaced errors (instead of abrupt termination).
  * Improved HTTP forwarding/response handling: correct hop-by-hop header stripping, stricter plugin action handling, and HTTP/3 request-body error propagation.
  * Stream ID allocation now **fails fast** when the ID space is exhausted.
  * Better reporting when observability initialization fails.
* **Security**
  * Auth tokens are redacted from debug output; auth failures return a generic reason.
* **Documentation**
  * Updated guidance/tooling to **Rust 1.91+**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->