### PR TITLE
fix: rate limiter now throttles over-budget sessions

### DIFF
--- a/ferrotunnel-core/src/rate_limit.rs
+++ b/ferrotunnel-core/src/rate_limit.rs
@@ -37,6 +37,9 @@ fn scaled_burst(rate: NonZeroU32, burst_factor: NonZeroU32) -> NonZeroU32 {
     NonZeroU32::new(rate.get().saturating_mul(burst_factor.get())).unwrap_or(NonZeroU32::MAX)
 }
 
+/// Upper bound, in seconds of quota, on a single throttle wait.
+const MAX_THROTTLE_CHUNK_SECS: u32 = 30;
+
 /// Rate limiter for a single session
 #[derive(Clone)]
 pub struct SessionRateLimiter {
@@ -44,6 +47,8 @@ pub struct SessionRateLimiter {
     stream_limiter: Arc<RateLimiter<NotKeyed, InMemoryState, DefaultClock, NoOpMiddleware>>,
     /// Limits data throughput
     bytes_limiter: Arc<RateLimiter<NotKeyed, InMemoryState, DefaultClock, NoOpMiddleware>>,
+    bytes_burst: NonZeroU32,
+    bytes_per_sec: NonZeroU32,
 }
 
 impl SessionRateLimiter {
@@ -56,12 +61,14 @@ impl SessionRateLimiter {
         // burst would reject every real data frame.
         let stream_quota = Quota::per_second(config.streams_per_sec)
             .allow_burst(scaled_burst(config.streams_per_sec, config.burst_factor));
-        let bytes_quota = Quota::per_second(config.bytes_per_sec)
-            .allow_burst(scaled_burst(config.bytes_per_sec, config.burst_factor));
+        let bytes_burst = scaled_burst(config.bytes_per_sec, config.burst_factor);
+        let bytes_quota = Quota::per_second(config.bytes_per_sec).allow_burst(bytes_burst);
 
         Self {
             stream_limiter: Arc::new(RateLimiter::direct(stream_quota)),
             bytes_limiter: Arc::new(RateLimiter::direct(bytes_quota)),
+            bytes_burst,
+            bytes_per_sec: config.bytes_per_sec,
         }
     }
 
@@ -104,6 +111,38 @@ impl SessionRateLimiter {
     /// Async version - waits until data can be sent
     pub async fn wait_for_data(&self, _bytes: usize) {
         self.bytes_limiter.until_ready().await;
+    }
+
+    /// Wait until `bytes` of data conform to the byte-rate quota, consuming
+    /// them in bounded chunks so payloads larger than the burst capacity are
+    /// delayed rather than rejected. Invokes `on_progress` after each chunk;
+    /// chunks are capped at `MAX_THROTTLE_CHUNK_SECS` worth of quota, so the
+    /// callback runs at a bounded cadence regardless of configuration.
+    /// Zero-length payloads return immediately.
+    pub async fn throttle_data(&self, bytes: usize, mut on_progress: impl FnMut()) {
+        let mut remaining = bytes;
+        while remaining > 0 {
+            remaining = remaining.saturating_sub(self.throttle_chunk(remaining).await);
+            on_progress();
+        }
+    }
+
+    async fn throttle_chunk(&self, bytes: usize) -> usize {
+        let chunk_cap = self.bytes_burst.get().min(
+            self.bytes_per_sec
+                .get()
+                .saturating_mul(MAX_THROTTLE_CHUNK_SECS),
+        );
+        let capped = u32::try_from(bytes).unwrap_or(u32::MAX).min(chunk_cap);
+        debug_assert!(capped <= self.bytes_burst.get());
+        debug_assert!(capped > 0, "throttle_chunk called with zero-length payload");
+        let Some(n) = NonZeroU32::new(capped) else {
+            return 0;
+        };
+        if self.bytes_limiter.until_n_ready(n).await.is_err() {
+            return capped as usize;
+        }
+        capped as usize
     }
 }
 
@@ -210,5 +249,38 @@ mod tests {
         let limiter = SessionRateLimiter::new(&config);
         // InsufficientCapacity must fail closed.
         assert!(limiter.check_data(100).is_err());
+    }
+
+    #[tokio::test]
+    async fn throttle_data_reports_progress_per_bounded_chunk() {
+        let config = RateLimiterConfig {
+            streams_per_sec: NonZeroU32::new(100).unwrap(),
+            bytes_per_sec: NonZeroU32::new(1000).unwrap(),
+            burst_factor: NonZeroU32::new(200).unwrap(),
+        };
+        let limiter = SessionRateLimiter::new(&config);
+        let mut calls = 0u32;
+        limiter.throttle_data(120_000, || calls += 1).await;
+        assert_eq!(
+            calls, 4,
+            "a wait must be split into bounded chunks so progress runs between them"
+        );
+    }
+
+    #[tokio::test]
+    async fn throttle_data_delays_payloads_larger_than_burst() {
+        let config = RateLimiterConfig {
+            streams_per_sec: NonZeroU32::new(100).unwrap(),
+            bytes_per_sec: NonZeroU32::new(1000).unwrap(),
+            burst_factor: NonZeroU32::new(1).unwrap(),
+        };
+        let limiter = SessionRateLimiter::new(&config);
+        let started = std::time::Instant::now();
+        limiter.throttle_data(1500, || {}).await;
+        assert!(
+            started.elapsed() >= std::time::Duration::from_millis(400),
+            "payload larger than the burst capacity must be throttled, got {:?}",
+            started.elapsed()
+        );
     }
 }

--- a/ferrotunnel-core/src/tunnel/server.rs
+++ b/ferrotunnel-core/src/tunnel/server.rs
@@ -1,4 +1,5 @@
 use crate::auth::{constant_time_eq, validate_token_format};
+use crate::rate_limit::SessionRateLimiter;
 use crate::resource_limits::{ServerResourceLimits, SessionPermit};
 use crate::stream::{AnyMultiplexer, Multiplexer, PrioritizedFrame};
 use crate::transport::batched_sender::run_batched_sender;
@@ -6,7 +7,7 @@ use crate::transport::{self, BoxedStream, TransportConfig};
 use crate::tunnel::accept_backoff::{is_transient_accept_error, AcceptBackoff};
 use crate::tunnel::common::{clamp_u128_to_u64, read_initial_handshake_frame};
 use crate::tunnel::session::{Session, SessionStoreBackend, ShardedSessionStore};
-use ferrotunnel_common::{LimitsConfig, Result, TunnelError};
+use ferrotunnel_common::{LimitsConfig, RateLimitConfig, Result, TunnelError};
 use ferrotunnel_protocol::codec::TunnelCodec;
 use ferrotunnel_protocol::constants::{MAX_PROTOCOL_VERSION, MIN_PROTOCOL_VERSION};
 use ferrotunnel_protocol::frame::{CloseReason, Frame, HandshakeFrame, HandshakeStatus};
@@ -18,7 +19,7 @@ use tokio::net::TcpListener;
 #[cfg(feature = "quic")]
 use tokio::time::timeout;
 use tokio_util::codec::Framed;
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 use uuid::Uuid;
 
 #[cfg(feature = "quic")]
@@ -46,6 +47,7 @@ pub struct TunnelServer {
     /// `run` and `run_quic` are invoked.
     cleanup_handle: Option<tokio::task::JoinHandle<()>>,
     limits_config: LimitsConfig,
+    rate_limits: RateLimitConfig,
 }
 
 impl Drop for TunnelServer {
@@ -70,6 +72,7 @@ impl TunnelServer {
             transport_config: TransportConfig::default(),
             cleanup_handle: None,
             limits_config: LimitsConfig::default(),
+            rate_limits: RateLimitConfig::default(),
         }
     }
 
@@ -97,6 +100,21 @@ impl TunnelServer {
     #[must_use]
     pub fn with_limits(mut self, limits: LimitsConfig) -> Self {
         self.limits_config = limits;
+        self
+    }
+
+    /// Set the per-session rate limits applied to every accepted session.
+    ///
+    /// Over-budget data frames are throttled (delayed and delivered) rather
+    /// than dropped. Note that a very low byte rate combined with a large
+    /// `max_frame_bytes` can park a session for a long time: a frame larger
+    /// than the burst capacity waits for quota chunk by chunk. Each chunk is
+    /// bounded to roughly thirty seconds of quota, and the session heartbeat
+    /// is refreshed between chunks, so a long throttle is never evicted as
+    /// stale regardless of the configured rate.
+    #[must_use]
+    pub fn with_rate_limits(mut self, limits: RateLimitConfig) -> Self {
+        self.rate_limits = limits;
         self
     }
 
@@ -237,6 +255,7 @@ impl TunnelServer {
             let sessions = sessions.clone();
             let token = self.auth_token.clone();
             let limits = self.limits_config.clone();
+            let rate_limits = self.rate_limits.clone();
 
             tokio::spawn(async move {
                 if let Err(e) = Self::handle_connection(
@@ -247,6 +266,7 @@ impl TunnelServer {
                     session_permit,
                     handshake_timeout,
                     limits,
+                    rate_limits,
                 )
                 .await
                 {
@@ -256,7 +276,7 @@ impl TunnelServer {
         }
     }
 
-    #[allow(clippy::too_many_lines)]
+    #[allow(clippy::too_many_lines, clippy::too_many_arguments)]
     async fn handle_connection(
         stream: BoxedStream,
         addr: SocketAddr,
@@ -265,6 +285,7 @@ impl TunnelServer {
         _session_permit: SessionPermit,
         handshake_timeout: Duration,
         limits_config: LimitsConfig,
+        rate_limits: RateLimitConfig,
     ) -> Result<()> {
         let mut framed = Framed::new(stream, TunnelCodec::from_limits(&limits_config));
 
@@ -327,7 +348,8 @@ impl TunnelServer {
                     token,
                     capabilities,
                     Some(AnyMultiplexer::Tcp(multiplexer.clone())),
-                );
+                )
+                .with_rate_limiter(SessionRateLimiter::new(&rate_limits.into()));
 
                 if let Err(e) = sessions.add(session) {
                     warn!("Failed to register session: {}", e);
@@ -371,6 +393,7 @@ impl TunnelServer {
         sessions: SessionStoreBackend,
         multiplexer: Multiplexer,
     ) -> Result<()> {
+        let mut throttling = false;
         loop {
             #[cfg_attr(not(feature = "metrics"), allow(unused_variables))]
             let decode_start = Instant::now();
@@ -397,7 +420,8 @@ impl TunnelServer {
             };
 
             // Enforce per-session rate limits on the hot path (issue #119).
-            // Fail closed: deny stream opens and drop data frames when over limit.
+            // Deny stream opens when over limit; throttle over-budget data frames
+            // instead of dropping them so the tunneled byte stream stays intact.
             if let Some(limiter) = &rate_limiter {
                 match &frame {
                     Frame::OpenStream(open) if limiter.check_stream_open().is_err() => {
@@ -417,13 +441,33 @@ impl TunnelServer {
                         continue;
                     }
                     Frame::Data { data, .. } if limiter.check_data(data.len()).is_err() => {
-                        warn!(
+                        if !throttling {
+                            throttling = true;
+                            warn!(
+                                session_id = %session_id,
+                                bytes = data.len(),
+                                "Data rate limit exceeded; throttling session"
+                            );
+                        }
+                        debug!(
                             session_id = %session_id,
                             bytes = data.len(),
-                            "Data rate limit exceeded; dropping data frame"
+                            "Throttling over-budget data frame"
                         );
-                        continue;
+                        // Deliberate head-of-line blocking: the byte budget is
+                        // session-wide, so every stream on this session stalls while
+                        // one is over budget; backpressure reaches the client through
+                        // TCP flow control instead of dropping frames mid-stream.
+                        limiter
+                            .throttle_data(data.len(), || {
+                                // Touch the heartbeat so a long throttle is not evicted as stale.
+                                if let Some(mut session) = sessions.get_mut(&session_id) {
+                                    session.update_heartbeat();
+                                }
+                            })
+                            .await;
                     }
+                    Frame::Data { .. } => throttling = false,
                     _ => {}
                 }
             }
@@ -518,6 +562,7 @@ impl TunnelServer {
             let sessions = sessions.clone();
             let token = self.auth_token.clone();
             let limits = self.limits_config.clone();
+            let rate_limits = self.rate_limits.clone();
 
             tokio::spawn(async move {
                 if let Err(e) = Self::handle_quic_connection(
@@ -528,6 +573,7 @@ impl TunnelServer {
                     session_permit,
                     handshake_timeout,
                     limits,
+                    rate_limits,
                 )
                 .await
                 {
@@ -541,7 +587,7 @@ impl TunnelServer {
     ///
     /// Uses the first bidirectional stream as a control channel for handshake and heartbeats.
     /// Subsequent bidirectional streams carry data (each QUIC stream = one tunnel stream).
-    #[allow(clippy::too_many_lines)]
+    #[allow(clippy::too_many_lines, clippy::too_many_arguments)]
     async fn handle_quic_connection(
         connection: quinn::Connection,
         addr: SocketAddr,
@@ -550,6 +596,7 @@ impl TunnelServer {
         _session_permit: SessionPermit,
         handshake_timeout: Duration,
         limits_config: LimitsConfig,
+        rate_limits: RateLimitConfig,
     ) -> Result<()> {
         // Accept the control stream (first bidi stream opened by client)
         let (ctrl_send, ctrl_recv) = match timeout(handshake_timeout, connection.accept_bi()).await
@@ -626,7 +673,8 @@ impl TunnelServer {
                     token,
                     capabilities,
                     Some(AnyMultiplexer::Quic(quic_mux.clone())),
-                );
+                )
+                .with_rate_limiter(SessionRateLimiter::new(&rate_limits.into()));
 
                 if let Err(e) = sessions.add(session) {
                     warn!("Failed to register QUIC session: {}", e);
@@ -856,6 +904,7 @@ mod tests {
             permit,
             Duration::from_millis(1),
             LimitsConfig::default(),
+            RateLimitConfig::default(),
         )
         .await
         .unwrap_err();
@@ -1024,9 +1073,9 @@ mod tests {
         .with_rate_limiter(SessionRateLimiter::new(&tight));
         sessions.add(session).unwrap();
 
-        // Open stream 1, send 8 bytes (the whole 8-byte budget), then 8 more
-        // bytes (over budget -> must be dropped by the Frame::Data limiter arm).
         let mut client = Framed::new(client_side, TunnelCodec::new());
+        // Open stream 1, send 8 bytes (the whole 8-byte budget), then 8 more
+        // bytes (over budget -> must be throttled by the Frame::Data limiter arm).
         client
             .send(Frame::OpenStream(Box::new(OpenStreamFrame {
                 stream_id: 1,
@@ -1054,23 +1103,29 @@ mod tests {
         let (read_half, _write_half) = tokio::io::split(server_stream);
         let framed_read = tokio_util::codec::FramedRead::new(read_half, TunnelCodec::new());
         // Keep a multiplexer clone alive so the opened stream's channel stays open
-        // after `process_messages` returns; otherwise a dropped (rate-limited) frame
+        // after `process_messages` returns; otherwise a lost (rate-limited) frame
         // would be indistinguishable from channel-close EOF.
         let _keepalive = multiplexer.clone();
+        let started = Instant::now();
         TunnelServer::process_messages(framed_read, session_id, sessions, multiplexer)
             .await
             .unwrap();
+        assert!(
+            started.elapsed() >= Duration::from_millis(500),
+            "over-budget data frame must be throttled (delayed), got {:?}",
+            started.elapsed()
+        );
 
-        // The opened stream receives only the first (in-budget) data frame; the
-        // second is dropped, so a follow-up read has nothing more to deliver.
+        // The opened stream receives both data frames intact and in order; the
+        // second is delayed by the throttle instead of dropped.
         let mut stream = new_stream_rx.recv().await.unwrap();
         let mut buf = vec![0u8; 64];
         let first = stream.read(&mut buf).await.unwrap();
         assert_eq!(&buf[..first], b"AAAAAAAA");
-        let second = timeout(Duration::from_millis(300), stream.read(&mut buf)).await;
-        assert!(
-            second.is_err(),
-            "over-budget data frame must be dropped by the rate limiter"
-        );
+        let second = timeout(Duration::from_millis(300), stream.read(&mut buf))
+            .await
+            .expect("over-budget data frame must be delivered after throttling, not dropped")
+            .unwrap();
+        assert_eq!(&buf[..second], b"BBBBBBBB");
     }
 }

--- a/ferrotunnel/src/config.rs
+++ b/ferrotunnel/src/config.rs
@@ -10,7 +10,8 @@
 //! callers.
 
 use ferrotunnel_common::{
-    LimitsConfig, Result, TunnelError, DEFAULT_HTTP_PORT, DEFAULT_LOCAL_ADDR, DEFAULT_TUNNEL_PORT,
+    LimitsConfig, RateLimitConfig, Result, TunnelError, DEFAULT_HTTP_PORT, DEFAULT_LOCAL_ADDR,
+    DEFAULT_TUNNEL_PORT,
 };
 use ferrotunnel_core::validate_limits;
 use std::fmt;
@@ -173,6 +174,9 @@ pub struct ServerConfig {
 
     /// Resource limits for protocol framing and connection handling.
     pub(crate) limits: LimitsConfig,
+
+    /// Per-session rate limits enforced by the tunnel server.
+    pub(crate) rate_limits: RateLimitConfig,
 }
 
 impl ServerConfig {
@@ -230,6 +234,11 @@ impl ServerConfig {
     pub fn limits(&self) -> &LimitsConfig {
         &self.limits
     }
+
+    /// Per-session rate limits enforced by the tunnel server.
+    pub fn rate_limits(&self) -> &RateLimitConfig {
+        &self.rate_limits
+    }
 }
 
 impl fmt::Debug for ServerConfig {
@@ -246,6 +255,7 @@ impl fmt::Debug for ServerConfig {
         debug
             .field("token", &REDACTED)
             .field("limits", &self.limits)
+            .field("rate_limits", &self.rate_limits)
             .finish()
     }
 }
@@ -263,6 +273,7 @@ impl Default for ServerConfig {
             http3_key_path: None,
             token: String::new(),
             limits: LimitsConfig::default(),
+            rate_limits: RateLimitConfig::default(),
         }
     }
 }

--- a/ferrotunnel/src/server.rs
+++ b/ferrotunnel/src/server.rs
@@ -20,7 +20,7 @@
 //! ```
 
 use crate::config::ServerConfig;
-use ferrotunnel_common::config::{LimitsConfig, TlsConfig};
+use ferrotunnel_common::config::{LimitsConfig, RateLimitConfig, TlsConfig};
 use ferrotunnel_common::{Result, TunnelError};
 use ferrotunnel_core::resource_limits::ServerResourceLimits;
 use ferrotunnel_core::transport::{tls::TlsTransportConfig, TransportConfig};
@@ -128,6 +128,7 @@ impl Server {
         let tunnel_server = TunnelServer::new(config.bind_addr, config.token)
             .with_transport(transport_config)
             .with_limits(tunnel_limits)
+            .with_rate_limits(config.rate_limits.clone())
             .with_resource_limits(resource_limits);
 
         // Initialize plugins
@@ -380,6 +381,15 @@ impl ServerBuilder {
     #[must_use]
     pub fn limits(mut self, limits: &LimitsConfig) -> Self {
         self.config.limits = limits.clone();
+        self
+    }
+
+    /// Configure per-session rate limits (stream-open and byte rates).
+    ///
+    /// Defaults to [`RateLimitConfig::default`].
+    #[must_use]
+    pub fn rate_limits(mut self, limits: &RateLimitConfig) -> Self {
+        self.config.rate_limits = limits.clone();
         self
     }
 


### PR DESCRIPTION
Fixes https://github.com/ferro-labs/ferrotunnel/issues/167

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added improved data-rate throttling for large payloads by processing them in manageable chunks.
  * Added configurable per-session rate limits for tunnel connections.
  * Added support for configuring stream-open and byte-rate limits when starting the server.
  * Added progress updates while throttled data is delivered.

* **Bug Fixes**
  * Data frames exceeding the rate limit are now delayed and processed instead of dropped.
  * Preserved payload delivery order during throttling.
  * Session heartbeats remain active during extended throttling waits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR changes the behavior of the per-session rate limiter when data frames exceed the byte budget: instead of dropping the frame (the previous behavior), the server now delays and delivers it. This preserves the integrity of the tunneled byte stream under backpressure.

- **`throttle_data`/`throttle_chunk`**: New chunked-wait loop in `SessionRateLimiter`. Frames larger than the burst capacity are consumed in bounded 30-second segments; a progress callback touches the session heartbeat between segments so the session is not evicted as stale during a long throttle.
- **`TunnelServer::with_rate_limits`**: New builder method that wires a `RateLimitConfig` into both the TCP and QUIC `handle_connection` paths; each accepted session now has a rate limiter attached from this config (default 100 streams/s, 10 MB/s, burst×2).
- **`ServerConfig` / `ServerBuilder`**: Exposed the new `rate_limits` field through the public `ferrotunnel` API layer so library users can configure limits without touching core types.

<h3>Confidence Score: 4/5</h3>

Safe to merge for the common case; the throttle-instead-of-drop change is correct and well-tested, with one narrow edge case around very short session timeouts worth a follow-up.

The core logic is sound: chunked until_n_ready calls correctly bound wait time, token accounting has no double-counting, and the heartbeat callback keeps the session alive during long throttles under default configuration. The one scenario that could cause an unexpected disconnect — a session_timeout configured below 30 seconds — is outside the documented defaults and unlikely in practice, but the with_rate_limits doc comment overpromises by saying the session is never evicted as stale.

**Files Needing Attention:** ferrotunnel-core/src/rate_limit.rs (throttle_chunk error branch) and ferrotunnel-core/src/tunnel/server.rs (heartbeat callback when session is already gone) deserve a second look, though neither represents a defect under normal configuration.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| ferrotunnel-core/src/rate_limit.rs | Adds throttle_data / throttle_chunk with chunk-bounded waits and heartbeat callbacks. Token accounting is correct; the until_n_ready error-return path is dead code (debug_assert prevents reachability) but silently fails-open if ever reached in release builds. |
| ferrotunnel-core/src/tunnel/server.rs | Wires rate_limits config into handle_connection (TCP & QUIC), changes Frame::Data over-budget path from continue (drop) to throttle_data(...).await (delay), and uses the on_progress callback to keep the session heartbeat alive during long waits. |
| ferrotunnel/src/config.rs | Adds rate_limits: RateLimitConfig field to ServerConfig with accessor, Default, and Debug impl. Straightforward plumbing change. |
| ferrotunnel/src/server.rs | Forwards config.rate_limits to TunnelServer::with_rate_limits and adds ServerBuilder::rate_limits builder method. Pure plumbing; no logic. |

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant process_messages
    participant SessionRateLimiter
    participant SessionStore
    participant Multiplexer

    Client->>process_messages: Frame::Data (over budget)
    process_messages->>SessionStore: get_mut(session_id) → update_heartbeat + clone limiter
    process_messages->>SessionRateLimiter: check_data(data.len()) → Err
    loop throttle_data loop (chunk by chunk)
        process_messages->>SessionRateLimiter: throttle_chunk(remaining) → until_n_ready(capped)
        Note over SessionRateLimiter: waits ≤30s for quota tokens
        SessionRateLimiter-->>process_messages: capped bytes consumed
        process_messages->>SessionStore: on_progress() → update_heartbeat
    end
    process_messages->>Multiplexer: process_frame(frame) — deliver after throttle

    Client->>process_messages: Frame::Data (in budget)
    process_messages->>SessionStore: get_mut(session_id) → update_heartbeat + clone limiter
    process_messages->>SessionRateLimiter: check_data(data.len()) → Ok (tokens consumed)
    process_messages->>Multiplexer: process_frame(frame) — deliver immediately
```
</details>

<sub>Reviews (7): Last reviewed commit: ["fix: rate limiter now throttles over-bud..."](https://github.com/ferro-labs/ferrotunnel/commit/cd440295cc7cf7bb254c8730764a076ba77b0698) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48265937)</sub>

<!-- /greptile_comment -->