### PR TITLE
fix: make frame-channel send and receive safe against timeout cancellation

### DIFF
--- a/ferrotunnel-core/src/stream/multiplexer.rs
+++ b/ferrotunnel-core/src/stream/multiplexer.rs
@@ -20,17 +20,20 @@ use std::sync::{Arc, Mutex};
 use std::task::{Context, Poll};
 use std::time::Duration;
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
-use tokio::time::timeout;
 use tracing::warn;
 
-/// Maximum time to wait when sending a frame to the wire channel (`frame_tx`)
+/// Maximum time to keep retrying a send to the wire channel (`frame_tx`)
 /// before treating the peer as unreachable and failing the send.
 ///
 /// The `frame_tx` channel is drained by the batched sender. If that task exits
-/// (teardown) or stalls (network partition with a full channel), a plain
-/// `send().await` would block forever, preventing the read loop from observing
-/// EOF and hanging the session. Bounding every send with this deadline ensures
-/// teardown completes promptly. See issue #136.
+/// (teardown) or stalls (network partition with a full channel), an unbounded
+/// wait would prevent the read loop from observing EOF and hang the session.
+/// Sends retry `try_send_option` with a short backoff — polling only while the
+/// channel is full — and fail once this deadline passes, so teardown completes
+/// promptly and a delivered frame is never reported as timed out. The trade
+/// for that accuracy: blocked senders poll on 1–10 ms timers instead of
+/// parking in the channel's waitlist, so wakeup order among them is not
+/// preserved under sustained backpressure. See #136.
 const FRAME_SEND_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Pool for reusing read buffers in `VirtualStream`
@@ -76,14 +79,26 @@ async fn send_prioritized_frame(
     frame_tx: &AsyncSender<PrioritizedFrame>,
     frame: PrioritizedFrame,
 ) -> Result<()> {
-    match timeout(FRAME_SEND_TIMEOUT, frame_tx.send(frame)).await {
-        Ok(Ok(())) => Ok(()),
-        Ok(Err(e)) => Err(io::Error::new(io::ErrorKind::BrokenPipe, e.to_string()).into()),
-        Err(_) => Err(io::Error::new(
-            io::ErrorKind::TimedOut,
-            "timed out sending frame to wire channel",
-        )
-        .into()),
+    let mut item = Some(frame);
+    let deadline = tokio::time::Instant::now() + FRAME_SEND_TIMEOUT;
+    let mut backoff = Duration::from_millis(1);
+    loop {
+        match frame_tx.try_send_option(&mut item) {
+            Ok(true) => return Ok(()),
+            Ok(false) => {
+                let now = tokio::time::Instant::now();
+                if now >= deadline {
+                    return Err(io::Error::new(
+                        io::ErrorKind::TimedOut,
+                        "timed out sending frame to wire channel",
+                    )
+                    .into());
+                }
+                tokio::time::sleep(backoff.min(deadline.duration_since(now))).await;
+                backoff = (backoff * 2).min(Duration::from_millis(10));
+            }
+            Err(e) => return Err(io::Error::new(io::ErrorKind::BrokenPipe, e.to_string()).into()),
+        }
     }
 }
 
@@ -309,13 +324,25 @@ type SendFuture = Pin<Box<dyn std::future::Future<Output = io::Result<()>> + Sen
 /// into the future itself; a timeout or closed channel resolves to an error.
 fn bounded_send_future(tx: AsyncSender<PrioritizedFrame>, frame: PrioritizedFrame) -> SendFuture {
     Box::pin(async move {
-        match timeout(FRAME_SEND_TIMEOUT, tx.send(frame)).await {
-            Ok(Ok(())) => Ok(()),
-            Ok(Err(e)) => Err(io::Error::new(io::ErrorKind::BrokenPipe, e.to_string())),
-            Err(_) => Err(io::Error::new(
-                io::ErrorKind::TimedOut,
-                "timed out sending frame to wire channel",
-            )),
+        let mut item = Some(frame);
+        let deadline = tokio::time::Instant::now() + FRAME_SEND_TIMEOUT;
+        let mut backoff = Duration::from_millis(1);
+        loop {
+            match tx.try_send_option(&mut item) {
+                Ok(true) => return Ok(()),
+                Ok(false) => {
+                    let now = tokio::time::Instant::now();
+                    if now >= deadline {
+                        return Err(io::Error::new(
+                            io::ErrorKind::TimedOut,
+                            "timed out sending frame to wire channel",
+                        ));
+                    }
+                    tokio::time::sleep(backoff.min(deadline.duration_since(now))).await;
+                    backoff = (backoff * 2).min(Duration::from_millis(10));
+                }
+                Err(e) => return Err(io::Error::new(io::ErrorKind::BrokenPipe, e.to_string())),
+            }
         }
     })
 }
@@ -577,6 +604,7 @@ impl AsyncWrite for VirtualStream {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tokio::time::timeout;
 
     #[tokio::test]
     async fn test_stream_id_allocation() {

--- a/ferrotunnel-core/src/transport/batched_sender.rs
+++ b/ferrotunnel-core/src/transport/batched_sender.rs
@@ -15,18 +15,14 @@ use ferrotunnel_protocol::Frame;
 use kanal::AsyncReceiver;
 use std::io;
 use std::io::IoSlice;
-use std::time::{Duration, Instant};
+#[cfg(feature = "metrics")]
+use std::time::Instant;
 use tokio::io::{AsyncWrite, AsyncWriteExt};
-use tokio::time::timeout;
 use tokio_util::codec::Encoder;
 use tracing::warn;
 
 /// Maximum frames to batch before flushing
 const MAX_BATCH_SIZE: usize = 256;
-
-/// Batch timeout for collecting more frames (microseconds)
-/// Short enough to not hurt latency, long enough to batch effectively
-const BATCH_TIMEOUT_MICROS: u64 = 50;
 
 /// Minimum frames before we consider waiting for more
 /// If we have fewer frames, flush immediately for lower latency
@@ -40,7 +36,7 @@ const MIN_FRAMES_FOR_BATCHING: usize = 2;
 ///
 /// ## P2 Batching Strategy
 /// - Always try to batch frames for throughput
-/// - Short timeout (50µs) balances latency vs throughput
+/// - A single scheduler yield while batching balances latency vs throughput
 /// - Single frame: flush immediately (no wait)
 pub async fn run_batched_sender<W>(
     frame_rx: AsyncReceiver<PrioritizedFrame>,
@@ -71,20 +67,14 @@ pub async fn run_batched_sender<W>(
             }
         }
 
-        // If we got multiple frames, try to collect more with a short timeout
+        // If we got multiple frames, yield once so in-flight producers can enqueue
         // This improves throughput under load while keeping latency low
         if frames.len() >= MIN_FRAMES_FOR_BATCHING && frames.len() < MAX_BATCH_SIZE {
-            let deadline = Duration::from_micros(BATCH_TIMEOUT_MICROS);
-            let start = Instant::now();
-
+            tokio::task::yield_now().await;
             while frames.len() < MAX_BATCH_SIZE {
-                let remaining = deadline.saturating_sub(start.elapsed());
-                if remaining.is_zero() {
-                    break;
-                }
-                match timeout(remaining, frame_rx.recv()).await {
-                    Ok(Ok(pf)) => frames.push(pf),
-                    _ => break,
+                match frame_rx.try_recv() {
+                    Ok(Some(pf)) => frames.push(pf),
+                    Ok(None) | Err(_) => break,
                 }
             }
         }
@@ -236,8 +226,10 @@ mod tests {
     use ferrotunnel_protocol::codec::TunnelCodec;
     use ferrotunnel_protocol::frame::StreamPriority;
     use kanal::bounded_async;
+    use std::time::{Duration, Instant};
     use tokio::io::duplex;
     use tokio::io::AsyncReadExt;
+    use tokio::time::timeout;
 
     fn pf(priority: StreamPriority, frame: Frame) -> PrioritizedFrame {
         (priority, frame)
@@ -352,5 +344,33 @@ mod tests {
         );
 
         drop(tx);
+    }
+
+    #[tokio::test]
+    async fn batched_sender_delivers_every_frame() {
+        use futures::StreamExt;
+        use tokio_util::codec::FramedRead;
+
+        const N: u64 = 20_000;
+        let (tx, rx) = bounded_async::<PrioritizedFrame>(64);
+        let (client, server) = duplex(1 << 20);
+
+        tokio::spawn(run_batched_sender(rx, server, TunnelCodec::new()));
+        tokio::spawn(async move {
+            for i in 0..N {
+                tx.send((StreamPriority::Normal, Frame::Heartbeat { timestamp: i }))
+                    .await
+                    .unwrap();
+            }
+        });
+
+        let mut framed = FramedRead::new(client, TunnelCodec::new());
+        let mut seen = 0u64;
+        while seen < N {
+            match timeout(Duration::from_secs(5), framed.next()).await {
+                Ok(Some(Ok(_))) => seen += 1,
+                other => panic!("lost {} of {N} frames ({other:?})", N - seen),
+            }
+        }
     }
 }

--- a/ferrotunnel-core/src/transport/tcp_frame.rs
+++ b/ferrotunnel-core/src/transport/tcp_frame.rs
@@ -12,12 +12,12 @@ use std::future::Future;
 use std::pin::Pin;
 use std::time::Duration;
 use tokio::io::AsyncRead;
-use tokio::time::timeout;
 use tokio_util::codec::FramedRead;
 
-/// Maximum time to wait when pushing a frame to the batched-sender channel
-/// before treating the peer as unreachable. Bounds every send so a full or
-/// closed channel during teardown cannot block the caller forever (#136).
+/// Maximum time to keep retrying a push to the batched-sender channel before
+/// treating the peer as unreachable. Sends retry `try_send_option` with a
+/// short backoff and fail past this deadline, so a full or closed channel
+/// during teardown cannot stall the caller (#136).
 const FRAME_SEND_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Sends frames over TCP by pushing to the channel consumed by the batched sender task.
@@ -38,12 +38,24 @@ impl FrameSender for TcpFrameSender {
         Box::pin(async move {
             // Trait API has no priority; use Normal when sending via trait.
             // Fail fast on a full/closed channel instead of blocking forever (#136).
-            match timeout(FRAME_SEND_TIMEOUT, tx.send((StreamPriority::Normal, frame))).await {
-                Ok(Ok(())) => Ok(()),
-                Ok(Err(e)) => Err(ferrotunnel_common::TunnelError::Protocol(e.to_string())),
-                Err(_) => Err(ferrotunnel_common::TunnelError::Protocol(
-                    "timed out sending frame to wire channel".into(),
-                )),
+            let mut item = Some((StreamPriority::Normal, frame));
+            let deadline = tokio::time::Instant::now() + FRAME_SEND_TIMEOUT;
+            let mut backoff = Duration::from_millis(1);
+            loop {
+                match tx.try_send_option(&mut item) {
+                    Ok(true) => return Ok(()),
+                    Ok(false) => {
+                        let now = tokio::time::Instant::now();
+                        if now >= deadline {
+                            return Err(ferrotunnel_common::TunnelError::Protocol(
+                                "timed out sending frame to wire channel".into(),
+                            ));
+                        }
+                        tokio::time::sleep(backoff.min(deadline.duration_since(now))).await;
+                        backoff = (backoff * 2).min(Duration::from_millis(10));
+                    }
+                    Err(e) => return Err(ferrotunnel_common::TunnelError::Protocol(e.to_string())),
+                }
             }
         })
     }


### PR DESCRIPTION
 **Frame loss (the receive side — #168).** The batched sender's micro-batching
  window wrapped `frame_rx.recv()` in a 50 µs timeout. Cancelling kanal's
  receive future at the instant a sender completes a rendezvous hand-off into it
  destroys the frame while the sender observes success. The batch loop now
  parks only on an uncancellable bare `recv().await` for the first frame and
  drains the rest with non-blocking `try_recv()`, so no cancellable receive
  future exists — the loss window is closed by construction. A regression test
  (`batched_sender_delivers_every_frame`) pushes 20,000 frames through a
  contended channel and requires the wire to carry every one.

  **Phantom timeout (the three send sites).** `timeout(5s, send())` could
  report `TimedOut` for a frame that was delivered at the instant the timer
  expired (kanal's send future completes an in-flight hand-off on drop, so no
  frame was ever lost here — the verdict was the defect). Sends now retry
  `try_send_option`, keeping the frame caller-owned until the channel accepts
  it, with the same 5 s fail-fast deadline (#136), and the final backoff sleep
  is capped to the remaining deadline. Trade-off, documented on
  `FRAME_SEND_TIMEOUT`: blocked senders poll on 1–10 ms backoff timers instead
  of parking in the channel's waitlist, so wakeup ordering under sustained
  backpressure is not preserved; measured cost is a few percent under
  saturation, zero on the uncontended path.

  **Benchmarks** (`full_stack`, this branch vs `main`): `batched_sender` shows
  +1.8–4.3% time at batch sizes 8–128 (no change at 1) — the measured cost of
  replacing the timed accumulation window with a single yield, consistent with
  the ~1–4% saturated-channel figure from review. `multiplexer_stream_creation`
  improves ~5.8% (the retry-based send path is cheaper when uncontended). The
  codec groups, untouched by this PR, swung −11% to +2% between runs and
  indicate the noise band. `multiplexer_round_trip` could not be compared: it
  hangs identically on `main` and on this branch (the bench holds `_frame_rx`
  without draining it and nothing calls `process_frame`, so its final
  un-deadlined `read_exact` cannot complete) — happy to file that as a separate
  issue.

  Fixes #168